### PR TITLE
fix: add queryAllName to security warning

### DIFF
--- a/packages/backend/src/addCrudResolvers.ts
+++ b/packages/backend/src/addCrudResolvers.ts
@@ -26,7 +26,7 @@ export default (resourceName: string, { printSecurityWarning = true } = {}) => {
     `deleteMany${typeName}`,
   ];
   if (process.env.NODE_ENV === "development" && printSecurityWarning) {
-    const queries = [queryName, queryName, queryCountName];
+    const queries = [queryName, queryAllName, queryCountName];
     console.info("");
     console.info(
       `☝ The following resolvers were defined for the resource '${resourceName}' to make it compatible for react-admin`,


### PR DESCRIPTION
Hello, this repo is really awesome, I've been using this for few days.

I've been generating the permissions for `graphql-shield` using the `queries` and `mutations` variable inside `addCrudResolvers.ts`.

While doing so, I noticed duplicate rule being created because `queryName` specified twice inside the `queries`.

This diff will replace the duplicate `queryName` with `queryAllName`.
