### PR TITLE
Empty id variable prevent updating

### DIFF
--- a/packages/dataprovider/src/buildVariables.ts
+++ b/packages/dataprovider/src/buildVariables.ts
@@ -437,6 +437,7 @@ const buildData = (
       (params as UpdateParams)?.previousData?.[key] ?? null;
     // TODO in case the content of the array has changed but not the array itself?
     if (
+      !fieldData ||
       isEqual(fieldData, previousFieldData) ||
       (isNil(previousFieldData) && isNil(fieldData))
     ) {


### PR DESCRIPTION
When trying to update entity data variable is sent with {id: undefind} inside and prevent updating