### PR TITLE
Feature: Filtering on Scalar fields

### DIFF
--- a/packages/dataprovider/src/buildWhere.test.ts
+++ b/packages/dataprovider/src/buildWhere.test.ts
@@ -7,6 +7,8 @@ describe("buildWhere", () => {
   let testIntrospection: IntrospectionResult;
   let testUserResource: Resource;
   let testBlogPostResource: Resource;
+  let testFilterResource: Resource;
+
   beforeAll(async () => {
     testIntrospection = await getTestIntrospection();
     testUserResource = testIntrospection.resources.find(
@@ -15,9 +17,589 @@ describe("buildWhere", () => {
     testBlogPostResource = testIntrospection.resources.find(
       (r) => r.type.kind === "OBJECT" && r.type.name === "BlogPost",
     );
+    testFilterResource = testIntrospection.resources.find(
+      (r) => r.type.kind === "OBJECT" && r.type.name === "FilteringTest",
+    );
   });
 
-  it("can handle simple number values", async () => {
+  describe("properly handles suffixed fields", () => {
+    describe("separating suffix from field name", () => {
+      it("valid suffix gets separated", async () => {
+        const filter = {
+          intField_gt: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          intField: {
+            gt: 12,
+          },
+        });
+      });
+      it("invalid suffix gets ignored", async () => {
+        const filter = {
+          intField_bt: "12", // "bigger than"
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          intField_bt: {
+            equals: 12,
+          },
+        });
+      });
+      it("allows underscores in field name with valid suffix", async () => {
+        const filter = {
+          snake_field_gt: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          snake_field: {
+            gt: 12,
+          },
+        });
+      });
+      it("allows underscores in field name with invalid suffix", async () => {
+        const filter = {
+          snake_field_bt: "12", // "bigger than"
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          snake_field_bt: {
+            equals: 12,
+          },
+        });
+      });
+    });
+    describe("reverts to handling original field when", () => {
+      it("no comparator is provided", async () => {
+        const filter = {
+          intField: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          intField: {
+            equals: 12,
+          },
+        });
+      });
+      it("no comparator is recognized", async () => {
+        const filter = {
+          intField_bt: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          intField_bt: {
+            equals: 12,
+          },
+        });
+      });
+      it("separated field doesn't exist", async () => {
+        const filter = {
+          myIntField_gt: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({});
+      });
+      it("separated field exists but its type doesn't support comparison", async () => {
+        const filter = {
+          boolField_gt: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({});
+      });
+      it("value is an object", async () => {
+        const filter = {
+          intField_gt: {
+            value: "12",
+          },
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({});
+      });
+      it("value is an array", async () => {
+        const filter = {
+          intField_gt: ["12", "13"],
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({});
+      });
+    });
+    it("in case of conflict favors comparison", async () => {
+      const filter = {
+        intField_lt: "12",
+      };
+      const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+      // intField is Int
+      // intField_lt is String
+      // => picks lt comparison on Int
+      expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+        intField: {
+          lt: 12,
+        },
+      });
+    });
+    it("works with Boolean fields and explicit equal comparison", async () => {
+      const filter = {
+        boolField_equals: "true",
+      };
+
+      const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+      expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+        boolField: {
+          equals: true,
+        },
+      });
+    });
+    describe("works with String fields", () => {
+      it("equals", async () => {
+        const filter = {
+          stringField_equals: "aBc",
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          OR: [
+            {
+              stringField: {
+                equals: "aBc",
+              }
+            },
+            {
+              stringField: {
+                equals: "abc"
+              }
+            },
+            {
+              stringField: {
+                equals: "ABc"
+              }
+            }
+          ]
+        });
+      });
+      it("greater than", async () => {
+        const filter = {
+          stringField_gt: "aBc",
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          OR: [
+            {
+              stringField: {
+                gt: "aBc",
+              }
+            },
+            {
+              stringField: {
+                gt: "abc",
+              }
+            },
+            {
+              stringField: {
+                gt: "ABc",
+              }
+            }
+          ]
+        });
+      });
+      it("greater than or equal", async () => {
+        const filter = {
+          stringField_gte: "aBc",
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          OR: [
+            {
+              stringField: {
+                gte: "aBc",
+              }
+            },
+            {
+              stringField: {
+                gte: "abc",
+              }
+            },
+            {
+              stringField: {
+                gte: "ABc",
+              }
+            }
+          ]
+        });
+      });
+      it("lesser than", async () => {
+        const filter = {
+          stringField_lt: "aBc"
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          OR: [
+            {
+              stringField: {
+                lt: "aBc"
+              }
+            },
+            {
+              stringField: {
+                lt: "abc"
+              }
+            },
+            {
+              stringField: {
+                lt: "ABc"
+              }
+            }
+          ]
+        });
+      });
+      it("lesser than or equal", async () => {
+        const filter = {
+          stringField_lte: "aBc"
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          OR: [
+            {
+              stringField: {
+                lte: "aBc"
+              }
+            },
+            {
+              stringField: {
+                lte: "abc"
+              }
+            },
+            {
+              stringField: {
+                lte: "ABc"
+              }
+            }
+          ]
+        });
+      });
+      it("contains", async () => {
+        const filter = {
+          stringField_contains: "aBc"
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          OR: [
+            {
+              stringField: {
+                contains: "aBc"
+              }
+            },
+            {
+              stringField: {
+                contains: "abc"
+              }
+            },
+            {
+              stringField: {
+                contains: "ABc"
+              }
+            }
+          ]
+        });
+      });
+      it("starts with", async () => {
+        const filter = {
+          stringField_startsWith: "aBc"
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          OR: [
+            {
+              stringField: {
+                startsWith: "aBc"
+              }
+            },
+            {
+              stringField: {
+                startsWith: "abc"
+              }
+            },
+            {
+              stringField: {
+                startsWith: "ABc"
+              }
+            }
+          ]
+        });
+      });
+      it("ends with", async () => {
+        const filter = {
+          stringField_endsWith: "aBc"
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          OR: [
+            {
+              stringField: {
+                endsWith: "aBc"
+              }
+            },
+            {
+              stringField: {
+                endsWith: "abc"
+              }
+            },
+            {
+              stringField: {
+                endsWith: "ABc"
+              }
+            }
+          ]
+        });
+      });
+    });
+    describe("works with Int fields", () => {
+      it("equals", async () => {
+        const filter = {
+          intField_equals: "12",
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          intField: {
+            equals: 12,
+          },
+        });
+      });
+      it("greater than", async () => {
+        const filter = {
+          intField_gt: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          intField: {
+            gt: 12,
+          },
+        });
+      });
+      it("greater than or equal", async () => {
+        const filter = {
+          intField_gte: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          intField: {
+            gte: 12,
+          },
+        });
+      });
+      it("lesser than", async () => {
+        const filter = {
+          intField_lt: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          intField: {
+            lt: 12,
+          },
+        });
+      });
+      it("lesser than or equal", async () => {
+        const filter = {
+          intField_lte: "12",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          intField: {
+            lte: 12,
+          },
+        });
+      });
+    });
+    describe("works with Float fields", () => {
+      it("equals", async () => {
+        const filter = {
+          floatField_equals: "12.34",
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          floatField: {
+            equals: 12.34,
+          },
+        });
+      });
+      it("greater than", async () => {
+        const filter = {
+          floatField_gt: "12.34",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          floatField: {
+            gt: 12.34,
+          },
+        });
+      });
+      it("greater than or equal", async () => {
+        const filter = {
+          floatField_gte: "12.34",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          floatField: {
+            gte: 12.34,
+          },
+        });
+      });
+      it("lesser than", async () => {
+        const filter = {
+          floatField_lt: "12.34",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          floatField: {
+            lt: 12.34,
+          },
+        });
+      });
+      it("lesser than or equal", async () => {
+        const filter = {
+          floatField_lte: "12.34",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          floatField: {
+            lte: 12.34,
+          },
+        });
+      });
+    });
+    describe("works with DateTime fields", () => {
+      it("equals", async () => {
+        const filter = {
+          dateTimeField_equals: "2020-12-30",
+        };
+
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          dateTimeField: {
+            equals: new Date("2020-12-30"),
+          },
+        });
+      });
+      it("greater than", async () => {
+        const filter = {
+          dateTimeField_gt: "2020-12-30",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          dateTimeField: {
+            gt: new Date("2020-12-30"),
+          },
+        });
+      });
+      it("greater than or equal", async () => {
+        const filter = {
+          dateTimeField_gte: "2020-12-30",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          dateTimeField: {
+            gte: new Date("2020-12-30"),
+          },
+        });
+      });
+      it("lesser than", async () => {
+        const filter = {
+          dateTimeField_lt: "2020-12-30",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          dateTimeField: {
+            lt: new Date("2020-12-30"),
+          },
+        });
+      });
+      it("lesser than or equal", async () => {
+        const filter = {
+          dateTimeField_lte: "2020-12-30",
+        };
+        const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+        expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+          dateTimeField: {
+            lte: new Date("2020-12-30"),
+          },
+        });
+      });
+    });
+  });
+
+  it("can handle simple float values", async () => {
+    const filter = {
+      floatField: "12.34",
+    };
+
+    const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+    expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+      floatField: {
+        equals: 12.34,
+      },
+    });
+  });
+
+  it("can handle simple datetime values", async () => {
+    const filter = {
+      dateTimeField: "2020-12-30",
+    };
+
+    const result = buildWhere(filter, testFilterResource, testIntrospection);
+
+    expect(result).toEqual<NexusGenArgTypes["Query"]["filteringTests"]["where"]>({
+      dateTimeField: {
+        equals: new Date("2020-12-30"),
+      },
+    });
+  });
+
+  // below are previous tests which shouldn't be changed and should pass
+  it("can handle simple int values", async () => {
     const filter = {
       yearOfBirth: 1879,
     };
@@ -171,6 +753,7 @@ describe("buildWhere", () => {
       ],
     });
   });
+
   it("handles mix of raw and simple filters", async () => {
     //
 
@@ -253,6 +836,7 @@ describe("buildWhere", () => {
       ],
     });
   });
+
   it("handles mixes of arrays as well", async () => {
     const filter = {
       yearOfBirth: [1879, 1920],

--- a/packages/dataprovider/test-data/datamodel.prisma
+++ b/packages/dataprovider/test-data/datamodel.prisma
@@ -61,6 +61,19 @@ model User {
   comments        BlogPostComment[]
 }
 
+model FilteringTest {
+  id              Int   @id @default(autoincrement())
+  intField        Int
+  floatField      Float
+  stringField     String
+  dateTimeField   DateTime
+  boolField       Boolean
+  intField_lt     String
+  intField_bt     Int
+  snake_field     Int
+  snake_field_bt  Int
+}
+
 model SomePublicRecordWithIntId {
   id    Int    @default(autoincrement()) @id
   title String

--- a/packages/dataprovider/test-data/testSchema.ts
+++ b/packages/dataprovider/test-data/testSchema.ts
@@ -91,6 +91,22 @@ export const testSchema = (options: Options) => {
     },
   });
 
+  const FilteringTest = objectType({
+    name: "FilteringTest",
+    definition(t) {
+      t.model.id();
+      t.model.intField();
+      t.model.floatField();
+      t.model.stringField();
+      t.model.dateTimeField();
+      t.model.boolField();
+      t.model.intField_lt();
+      t.model.intField_bt();
+      t.model.snake_field();
+      t.model.snake_field_bt();
+    },
+  });
+
   const BlogPostComment = objectType({
     name: "BlogPostComment",
     definition(t) {
@@ -124,12 +140,14 @@ export const testSchema = (options: Options) => {
     BlogPost,
     BlogPostComment,
     UserCreateOneWithoutCommentsInput,
+    FilteringTest,
 
     addCrudResolvers("User", options),
     addCrudResolvers("UserRole", options),
     addCrudResolvers("SomePublicRecordWithIntId", options),
     addCrudResolvers("BlogPost", options),
     addCrudResolvers("BlogPostComment", options),
+    addCrudResolvers("FilteringTest", options),
   ];
 
   return makeSchema({


### PR DESCRIPTION
## EDIT: See latest comment for current info on the MR

For `DateTime` Prisma fields, there is a `DateTimeFilter` and `DateTimeNullableFilter` input type generated, in the form of 
```gql
input DateTimeFilter {
  equals: DateTime
  in: [DateTime]
  notIn: [DateTime]
  lt: DateTime
  lte: DateTime
  gt: DateTime
  gte: DateTime
  not: NestedDateTimeFilter
}
```

Before this merge request, if you tried to use `DateTime` field in react-admin's `<Filter>`, e.g.

```jsx
<DateInput source="effectiveFrom" />
```

the data provider would not recognize it's a `DateTimeFilter` and produces a query like this:

```js
where: { effectiveFrom: { id: { equals: '2020-12-30' } } }
```

which would turn into a 400 Bad Request for the query.

This merge request implements basic filtering on `DateTime` fields by using an "artificial" field name (inspiration taken from React Admin's [demo](https://github.com/marmelab/react-admin/blob/master/examples/demo/src/orders/OrderList.tsx#L48)). Now, you can filter DateTime fields by equal comparison, or with operations >, >=, <, <= in the following way (taking a field `effectiveFrom` as an example):

- using `source="effectiveFrom"` without any suffix generates 
    `where: { effectiveFrom: { equals: '2020-12-30T00:00:00.000Z' } }`
- using `source="effectiveFrom_lt"` uses lesser than comparison and generates 
    `where: { effectiveFrom: { lt: '2020-12-30T00:00:00.000Z' } }`
- similarly for `lte`, `gt`, `gte`

The technical limitation of this approach is that users can't use `_` in **any** field names (in which case, a different separator, maybe `:` would be a safer choice for users with snake_case field names). 

I also included several tests (and others passed as well so I think this change shouldn't break anything else), but generating the types (via `yarn generate:test:nexus`) failed for me so I'm not sure if I didn't make any mistakes there.

TODO: If you would want, I could try to implement the rest of the filter fields (`in`, `notIn`, `not`) as well, but for our use case this wasn't necessary.


