### PR TITLE
Feature: Separate resource fragments

### DIFF
--- a/packages/dataprovider/README.md
+++ b/packages/dataprovider/README.md
@@ -159,7 +159,7 @@ To fix this, you can specify a `ResourceView` to do that:
 buildGraphQLProvider({
   clientOptions: { uri: "/api/graphql" } as any,
   resourceViews: {
-    AllParticipantsToInvoice: {
+    ParticipantsToInvoice: {
       resource: "ChallengeParticipation",
       fragment: gql`
         fragment Billing on ChallengeParticipation {
@@ -252,7 +252,7 @@ buildGraphQLProvider({
   },
 })
 ```
-Now you have a new virtual resource `AllParticipantsToInvoice` that can be used to display a List or for one record. (notice: update/create/delete is currently not specified, so use it read-only) and it will have exactly this data.
+Now you have a new virtual resource `ParticipantsToInvoice` that can be used to display a List or for one record. (notice: update/create/delete is currently not specified, so use it read-only) and it will have exactly this data.
 
 There are two ways you can use this new virtual resource. If you want to use it with React-Admin's query hooks (`useQuery, useGetList, useGetOne`), you need to add this as a new `<Resource>`, because these hooks rely on Redux store and it will throw an error if the resource is unknown:
 ```jsx

--- a/packages/dataprovider/README.md
+++ b/packages/dataprovider/README.md
@@ -254,13 +254,14 @@ buildGraphQLProvider({
 ```
 Now you have a new virtual resource `ParticipantsToInvoice` that can be used to display a List or for one record. (notice: update/create/delete is currently not specified, so use it read-only) and it will have exactly this data.
 
-There are two ways you can use this new virtual resource. If you want to use it with React-Admin's query hooks (`useQuery, useGetList, useGetOne`), you need to add this as a new `<Resource>`, because these hooks rely on Redux store and it will throw an error if the resource is unknown:
+There are two ways you can use this new virtual resource. If you want to use it with React-Admin's query hooks (`useQuery, useGetList, useGetOne`), you need to add this as a new `<Resource>`:
 ```jsx
 <Admin>
   // ...
   <Resource name="ParticipantsToInvoice" />
 </Admin>
 ```
+These hooks rely on Redux store and will throw an error if the resource isn't defined.
 
 However, if you directly use data provider calls, you can use it with defined `<Resource>` but also _without_ as it directly calls data provider.
 ```ts

--- a/packages/dataprovider/src/buildQuery.test.ts
+++ b/packages/dataprovider/src/buildQuery.test.ts
@@ -211,6 +211,186 @@ describe("buildQueryFactory", () => {
           }
         `);
       });
+      it("for get many fetch", () => {
+        const buildQuery = buildQueryFactory(testIntrospection, {
+          resourceViews: {
+            UserWithTwitter: {
+              resource: "User",
+              fragment: {
+                one: gqlReal`
+                  fragment OneUserWithTwitter on User {
+                    id
+                    socialMedia {
+                      twitter
+                    }
+                  }
+                `,
+                many: gqlReal`
+                  fragment ManyUsersWithTwitter on User {
+                    id
+                    email
+                    wantsNewsletter
+                    socialMedia {
+                      twitter
+                    }
+                  }
+                `,
+              },
+            },
+          },
+        });
+
+        const { query } = buildQuery("GET_MANY", "UserWithTwitter", {
+          ids: [1, 2],
+        });
+
+        expect(query).toEqualGraphql(gql`
+          query users($where: UserWhereInput) {
+            items: users(where: $where) {
+              id
+              email
+              wantsNewsletter
+              socialMedia {
+                twitter
+              }
+            }
+            total: usersCount(where: $where)
+          }
+        `);
+      });
+      it("for get many reference fetch", () => {
+        const buildQuery = buildQueryFactory(testIntrospection, {
+          resourceViews: {
+            UserWithTwitter: {
+              resource: "User",
+              fragment: {
+                one: gqlReal`
+                  fragment OneUserWithTwitter on User {
+                    id
+                    socialMedia {
+                      twitter
+                    }
+                  }
+                `,
+                many: gqlReal`
+                  fragment ManyUsersWithTwitter on User {
+                    id
+                    email
+                    wantsNewsletter
+                    socialMedia {
+                      twitter
+                    }
+                  }
+                `,
+              },
+            },
+          },
+        });
+
+        const { query } = buildQuery("GET_MANY_REFERENCE", "UserWithTwitter", {
+          pagination: {
+            page: 1,
+            perPage: 50,
+          },
+          sort: {},
+          id: 1,
+          target: "id",
+        });
+
+        expect(query).toEqualGraphql(gql`
+          query users(
+            $where: UserWhereInput
+            $orderBy: [UserOrderByInput!]
+            $take: Int
+            $skip: Int
+          ) {
+            items: users(
+              where: $where
+              orderBy: $orderBy
+              take: $take
+              skip: $skip
+            ) {
+              id
+              email
+              wantsNewsletter
+              socialMedia {
+                twitter
+              }
+            }
+            total: usersCount(where: $where)
+          }
+        `);
+      });
+      describe("should throw an error if only one fragment is defined", () => {
+        it("only one", () => {
+          const buildQuery = buildQueryFactory(testIntrospection, {
+            resourceViews: {
+              UserWithTwitter: {
+                resource: "User",
+                // @ts-ignore
+                fragment: {
+                  one: gqlReal`
+                    fragment OneUserWithTwitter on User {
+                      id
+                      socialMedia {
+                        twitter
+                      }
+                    }
+                  `,
+                },
+              },
+            },
+          });
+
+          expect(() => {
+            buildQuery("GET_LIST", "UserWithTwitter", {
+              pagination: {
+                page: 1,
+                perPage: 50,
+              },
+              filter: {},
+              sort: {},
+            } as GetListParams);
+          }).toThrowError(
+            "Error in resource view UserWithTwitter - you either must specify both 'one' and 'many' fragments or use a single fragment for both.",
+          );
+        });
+        it("only many", () => {
+          const buildQuery = buildQueryFactory(testIntrospection, {
+            resourceViews: {
+              UserWithTwitter: {
+                resource: "User",
+                // @ts-ignore
+                fragment: {
+                  many: gqlReal`
+                    fragment ManyUsersWithTwitter on User {
+                      id
+                      email
+                      wantsNewsletter
+                      socialMedia {
+                        twitter
+                      }
+                    }
+                  `,
+                },
+              },
+            },
+          });
+
+          expect(() => {
+            buildQuery("GET_LIST", "UserWithTwitter", {
+              pagination: {
+                page: 1,
+                perPage: 50,
+              },
+              filter: {},
+              sort: {},
+            } as GetListParams);
+          }).toThrowError(
+            "Error in resource view UserWithTwitter - you either must specify both 'one' and 'many' fragments or use a single fragment for both.",
+          );
+        });
+      });
     });
   });
 });

--- a/packages/dataprovider/src/buildQuery.ts
+++ b/packages/dataprovider/src/buildQuery.ts
@@ -54,7 +54,7 @@ export const buildQueryFactory = (
         fragment = resourceView.fragment as DocumentNode;
       } else {
         throw new Error(
-          `Error in resource view ${resourceName} - you either must specify both 'one' and 'many' fragment or use a single fragment for both.`,
+          `Error in resource view ${resourceName} - you either must specify both 'one' and 'many' fragments or use a single fragment for both.`,
         );
       }
     }

--- a/packages/dataprovider/src/types.ts
+++ b/packages/dataprovider/src/types.ts
@@ -1,8 +1,13 @@
 import { DocumentNode } from "graphql";
 
+export type DoubleFragment = {
+  one: DocumentNode;
+  many: DocumentNode;
+};
+
 export type ResourceView = {
   resource: string;
-  fragment: DocumentNode;
+  fragment: DocumentNode | DoubleFragment;
 };
 
 export type OurOptions = {


### PR DESCRIPTION
Should resolve #40 

I tried to implement different resource fragments for List and Detail view. Seems to work well, but truth be told I only tried fetching the data with `getList`, `getOne` and direct data provider calls. I have **not** tried creating a `<List>` or `<Show>` component for this virtual resource and just **assume** it should work, if underlying calls to the data provider work. I also updated the readme to document this new behavior.

I think I've understood how to use `git rebase`, so I declare this PR as a draft to get your feedback and once it's ready, I'll squash into a single `feat: ` commit and remove the draft status. If I manage to mess up again, I'll fix it somehow differently 😄 