### PR TITLE
fix: add new createMany ModifierParam

### DIFF
--- a/packages/dataprovider/src/buildVariables.test.ts
+++ b/packages/dataprovider/src/buildVariables.test.ts
@@ -680,6 +680,7 @@ describe("buildVariables", () => {
         data: {
           id: "einstein",
           roles: [{ name: "Student Role" }, { id: "human", name: "Human" }],
+          blogPosts: [{ text: "Lorem ipsum", title: "My super post" }],
         },
         previousData: {
           roles: [{ id: "human", name: "Human" }],
@@ -693,6 +694,9 @@ describe("buildVariables", () => {
         data: {
           roles: {
             create: [{ name: "Student Role" }],
+          },
+          blogPosts: {
+            create: [{ text: "Lorem ipsum", title: "My super post" }],
           },
         },
       });

--- a/packages/dataprovider/src/buildVariables.ts
+++ b/packages/dataprovider/src/buildVariables.ts
@@ -33,6 +33,7 @@ export interface GetListParams {
 enum ModifiersParams {
   connect = "connect",
   create = "create",
+  createMany = "createMany",
   delete = "delete",
   deleteMany = "deleteMany",
   disconnect = "disconnect",


### PR DESCRIPTION
Prisma has introduced a new key on the relation inputs: `createMany`

In order to recognize if the field isRelationship it must be added to the ModifiersParams.

```ts
const isRelationship = fullFieldObjectType?.inputFields.every((i) => {
  return Object.keys(ModifiersParams).includes(i.name);
});
```

This new 'createMany' method could be utilized. Before chosing 'create' vs 'createMany' the dataprovider should search the subtree for additional relations as the 'createMany' is not supporting it.
https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries/#create-a-single-record-and-multiple-related-records