### PR TITLE
fix: update by nullable relation list

### DIFF
--- a/packages/dataprovider/src/buildVariables.ts
+++ b/packages/dataprovider/src/buildVariables.ts
@@ -5,6 +5,7 @@ import {
   IntrospectionListTypeRef,
   IntrospectionNamedTypeRef,
   IntrospectionNonNullTypeRef,
+  IntrospectionTypeRef,
 } from "graphql";
 import isEqual from "lodash/isEqual";
 import isNil from "lodash/isNil";
@@ -158,10 +159,14 @@ const getUpdateInputDataTypeForList = (
       introdspectionType.name === updateInputFieldType.name,
   ) as IntrospectionInputObjectType).inputFields.find(
     (input) => input.name === "data",
-  ).type as IntrospectionNonNullTypeRef<IntrospectionNamedTypeRef>;
+  ).type as IntrospectionTypeRef;
+
+  const updateListInputDataName = ((updateListInputDataType.kind === "NON_NULL"
+    ? updateListInputDataType.ofType
+    : updateListInputDataType) as IntrospectionNamedTypeRef).name;
+
   return introspectionResults.types.find(
-    (introdspectionType) =>
-      introdspectionType.name === updateListInputDataType.ofType.name,
+    (introdspectionType) => introdspectionType.name === updateListInputDataName,
   ) as IntrospectionInputObjectType;
 };
 


### PR DESCRIPTION
I have found that you are testing against only non nullable list relations (e.g.):

```gql
input UserRoleUpdateManyWithoutUsersInput {
  connect: [UserRoleWhereUniqueInput!]
  connectOrCreate: [UserRoleCreateOrConnectWithoutUsersInput!]
  create: [UserRoleCreateWithoutUsersInput!]
  delete: [UserRoleWhereUniqueInput!]
  deleteMany: [UserRoleScalarWhereInput!]
  disconnect: [UserRoleWhereUniqueInput!]
  set: [UserRoleWhereUniqueInput!]
  update: [UserRoleUpdateWithWhereUniqueWithoutUsersInput!]
  updateMany: [UserRoleUpdateManyWithWhereWithoutUsersInput!]
  upsert: [UserRoleUpsertWithWhereUniqueWithoutUsersInput!]
}
```

however in my schema I have nullable relations as well
```gql
input ScheduleUpdateManyWithoutClassInput {
  connect: [ScheduleWhereUniqueInput]
  connectOrCreate: [ScheduleCreateOrConnectWithoutClassInput]
  create: [ScheduleCreateWithoutClassInput]
  delete: [ScheduleWhereUniqueInput]
  deleteMany: [ScheduleScalarWhereInput]
  disconnect: [ScheduleWhereUniqueInput]
  set: [ScheduleWhereUniqueInput]
  update: [ScheduleUpdateWithWhereUniqueWithoutClassInput]
  updateMany: [ScheduleUpdateManyWithWhereWithoutClassInput]
  upsert: [ScheduleUpsertWithWhereUniqueWithoutClassInput]
}
```

So in my case searching the ofType's name of the simple ScheduleUpdateWithWhereUniqueWithoutClassInput will fail.