### PR TITLE
Deleting relations if disconnect operation is not present

### DIFF
--- a/packages/dataprovider/generated/nexus-prisma.ts
+++ b/packages/dataprovider/generated/nexus-prisma.ts
@@ -18,6 +18,7 @@ interface PrismaModels {
   UserSocialMedia: Prisma.UserSocialMedia
   BlogPost: Prisma.BlogPost
   BlogPostComment: Prisma.BlogPostComment
+  Cat: Prisma.Cat
   User: Prisma.User
   FilteringTest: Prisma.FilteringTest
   SomePublicRecordWithIntId: Prisma.SomePublicRecordWithIntId
@@ -46,9 +47,13 @@ interface NexusPrismaInputs {
       filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'text' | 'post' | 'postId' | 'author' | 'authorId'
       ordering: 'id' | 'text' | 'post' | 'postId' | 'author' | 'authorId'
     }
+    cats: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'name' | 'owner' | 'userId'
+      ordering: 'id' | 'name' | 'owner' | 'userId'
+    }
     users: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate'
-      ordering: 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate'
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'cat'
+      ordering: 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'cat'
     }
     filteringTests: {
       filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'intField' | 'floatField' | 'stringField' | 'dateTimeField' | 'boolField' | 'intField_lt' | 'intField_bt' | 'snake_field' | 'snake_field_bt'
@@ -61,8 +66,8 @@ interface NexusPrismaInputs {
   },
   UserRole: {
     users: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate'
-      ordering: 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate'
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'cat'
+      ordering: 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'cat'
     }
   }
   Company: {
@@ -78,6 +83,9 @@ interface NexusPrismaInputs {
     }
   }
   BlogPostComment: {
+
+  }
+  Cat: {
 
   }
   User: {
@@ -119,6 +127,8 @@ interface NexusPrismaOutputs {
     blogPosts: 'BlogPost'
     blogPostComment: 'BlogPostComment'
     blogPostComments: 'BlogPostComment'
+    cat: 'Cat'
+    cats: 'Cat'
     user: 'User'
     users: 'User'
     filteringTest: 'FilteringTest'
@@ -157,6 +167,12 @@ interface NexusPrismaOutputs {
     deleteOneBlogPostComment: 'BlogPostComment'
     deleteManyBlogPostComment: 'AffectedRowsOutput'
     upsertOneBlogPostComment: 'BlogPostComment'
+    createOneCat: 'Cat'
+    updateOneCat: 'Cat'
+    updateManyCat: 'AffectedRowsOutput'
+    deleteOneCat: 'Cat'
+    deleteManyCat: 'AffectedRowsOutput'
+    upsertOneCat: 'Cat'
     createOneUser: 'User'
     updateOneUser: 'User'
     updateManyUser: 'AffectedRowsOutput'
@@ -210,6 +226,12 @@ interface NexusPrismaOutputs {
     author: 'User'
     authorId: 'String'
   }
+  Cat: {
+    id: 'String'
+    name: 'String'
+    owner: 'User'
+    userId: 'String'
+  }
   User: {
     id: 'String'
     email: 'String'
@@ -226,6 +248,7 @@ interface NexusPrismaOutputs {
     comments: 'BlogPostComment'
     companies: 'Company'
     weddingDate: 'DateTime'
+    cat: 'Cat'
   }
   FilteringTest: {
     id: 'Int'
@@ -252,6 +275,7 @@ interface NexusPrismaMethods {
   UserSocialMedia: Typegen.NexusPrismaFields<'UserSocialMedia'>
   BlogPost: Typegen.NexusPrismaFields<'BlogPost'>
   BlogPostComment: Typegen.NexusPrismaFields<'BlogPostComment'>
+  Cat: Typegen.NexusPrismaFields<'Cat'>
   User: Typegen.NexusPrismaFields<'User'>
   FilteringTest: Typegen.NexusPrismaFields<'FilteringTest'>
   SomePublicRecordWithIntId: Typegen.NexusPrismaFields<'SomePublicRecordWithIntId'>

--- a/packages/dataprovider/generated/nexus-prisma.ts
+++ b/packages/dataprovider/generated/nexus-prisma.ts
@@ -18,7 +18,7 @@ interface PrismaModels {
   UserSocialMedia: Prisma.UserSocialMedia
   BlogPost: Prisma.BlogPost
   BlogPostComment: Prisma.BlogPostComment
-  Cat: Prisma.Cat
+  Site: Prisma.Site
   User: Prisma.User
   FilteringTest: Prisma.FilteringTest
   SomePublicRecordWithIntId: Prisma.SomePublicRecordWithIntId
@@ -47,13 +47,13 @@ interface NexusPrismaInputs {
       filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'text' | 'post' | 'postId' | 'author' | 'authorId'
       ordering: 'id' | 'text' | 'post' | 'postId' | 'author' | 'authorId'
     }
-    cats: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'name' | 'owner' | 'userId'
-      ordering: 'id' | 'name' | 'owner' | 'userId'
+    sites: {
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'name' | 'url' | 'owner' | 'userId'
+      ordering: 'id' | 'name' | 'url' | 'owner' | 'userId'
     }
     users: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'cat'
-      ordering: 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'cat'
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'site'
+      ordering: 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'site'
     }
     filteringTests: {
       filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'intField' | 'floatField' | 'stringField' | 'dateTimeField' | 'boolField' | 'intField_lt' | 'intField_bt' | 'snake_field' | 'snake_field_bt'
@@ -66,8 +66,8 @@ interface NexusPrismaInputs {
   },
   UserRole: {
     users: {
-      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'cat'
-      ordering: 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'cat'
+      filtering: 'AND' | 'OR' | 'NOT' | 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'site'
+      ordering: 'id' | 'email' | 'roles' | 'firstName' | 'lastName' | 'gender' | 'yearOfBirth' | 'wantsNewsletter' | 'interests' | 'userSocialMedia' | 'address' | 'blogPosts' | 'comments' | 'companies' | 'weddingDate' | 'site'
     }
   }
   Company: {
@@ -85,7 +85,7 @@ interface NexusPrismaInputs {
   BlogPostComment: {
 
   }
-  Cat: {
+  Site: {
 
   }
   User: {
@@ -127,8 +127,8 @@ interface NexusPrismaOutputs {
     blogPosts: 'BlogPost'
     blogPostComment: 'BlogPostComment'
     blogPostComments: 'BlogPostComment'
-    cat: 'Cat'
-    cats: 'Cat'
+    site: 'Site'
+    sites: 'Site'
     user: 'User'
     users: 'User'
     filteringTest: 'FilteringTest'
@@ -167,12 +167,12 @@ interface NexusPrismaOutputs {
     deleteOneBlogPostComment: 'BlogPostComment'
     deleteManyBlogPostComment: 'AffectedRowsOutput'
     upsertOneBlogPostComment: 'BlogPostComment'
-    createOneCat: 'Cat'
-    updateOneCat: 'Cat'
-    updateManyCat: 'AffectedRowsOutput'
-    deleteOneCat: 'Cat'
-    deleteManyCat: 'AffectedRowsOutput'
-    upsertOneCat: 'Cat'
+    createOneSite: 'Site'
+    updateOneSite: 'Site'
+    updateManySite: 'AffectedRowsOutput'
+    deleteOneSite: 'Site'
+    deleteManySite: 'AffectedRowsOutput'
+    upsertOneSite: 'Site'
     createOneUser: 'User'
     updateOneUser: 'User'
     updateManyUser: 'AffectedRowsOutput'
@@ -226,9 +226,10 @@ interface NexusPrismaOutputs {
     author: 'User'
     authorId: 'String'
   }
-  Cat: {
+  Site: {
     id: 'String'
     name: 'String'
+    url: 'String'
     owner: 'User'
     userId: 'String'
   }
@@ -248,7 +249,7 @@ interface NexusPrismaOutputs {
     comments: 'BlogPostComment'
     companies: 'Company'
     weddingDate: 'DateTime'
-    cat: 'Cat'
+    site: 'Site'
   }
   FilteringTest: {
     id: 'Int'
@@ -275,7 +276,7 @@ interface NexusPrismaMethods {
   UserSocialMedia: Typegen.NexusPrismaFields<'UserSocialMedia'>
   BlogPost: Typegen.NexusPrismaFields<'BlogPost'>
   BlogPostComment: Typegen.NexusPrismaFields<'BlogPostComment'>
-  Cat: Typegen.NexusPrismaFields<'Cat'>
+  Site: Typegen.NexusPrismaFields<'Site'>
   User: Typegen.NexusPrismaFields<'User'>
   FilteringTest: Typegen.NexusPrismaFields<'FilteringTest'>
   SomePublicRecordWithIntId: Typegen.NexusPrismaFields<'SomePublicRecordWithIntId'>

--- a/packages/dataprovider/generated/nexus.ts
+++ b/packages/dataprovider/generated/nexus.ts
@@ -248,9 +248,9 @@ export interface NexusGenInputs {
     title?: NexusGenEnums['SortOrder'] | null; // SortOrder
   }
   BlogPostScalarWhereInput: { // input type
-    AND?: NexusGenInputs['BlogPostScalarWhereInput'][] | null; // [BlogPostScalarWhereInput!]
-    NOT?: NexusGenInputs['BlogPostScalarWhereInput'][] | null; // [BlogPostScalarWhereInput!]
-    OR?: NexusGenInputs['BlogPostScalarWhereInput'][] | null; // [BlogPostScalarWhereInput!]
+    AND?: Array<NexusGenInputs['BlogPostScalarWhereInput'] | null> | null; // [BlogPostScalarWhereInput]
+    NOT?: Array<NexusGenInputs['BlogPostScalarWhereInput'] | null> | null; // [BlogPostScalarWhereInput]
+    OR?: Array<NexusGenInputs['BlogPostScalarWhereInput'] | null> | null; // [BlogPostScalarWhereInput]
     authorId?: NexusGenInputs['StringNullableFilter'] | null; // StringNullableFilter
     id?: NexusGenInputs['StringFilter'] | null; // StringFilter
     text?: NexusGenInputs['StringFilter'] | null; // StringFilter
@@ -269,21 +269,20 @@ export interface NexusGenInputs {
     title?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
   }
   BlogPostUpdateManyWithWhereWithoutAuthorInput: { // input type
-    data: NexusGenInputs['BlogPostUpdateManyMutationInput']; // BlogPostUpdateManyMutationInput!
-    where: NexusGenInputs['BlogPostScalarWhereInput']; // BlogPostScalarWhereInput!
+    data?: NexusGenInputs['BlogPostUpdateManyMutationInput'] | null; // BlogPostUpdateManyMutationInput
+    where?: NexusGenInputs['BlogPostScalarWhereInput'] | null; // BlogPostScalarWhereInput
   }
   BlogPostUpdateManyWithoutAuthorInput: { // input type
-    connect?: NexusGenInputs['BlogPostWhereUniqueInput'][] | null; // [BlogPostWhereUniqueInput!]
-    connectOrCreate?: NexusGenInputs['BlogPostCreateOrConnectWithoutAuthorInput'][] | null; // [BlogPostCreateOrConnectWithoutAuthorInput!]
-    create?: NexusGenInputs['BlogPostCreateWithoutAuthorInput'][] | null; // [BlogPostCreateWithoutAuthorInput!]
+    connect?: Array<NexusGenInputs['BlogPostWhereUniqueInput'] | null> | null; // [BlogPostWhereUniqueInput]
+    connectOrCreate?: Array<NexusGenInputs['BlogPostCreateOrConnectWithoutAuthorInput'] | null> | null; // [BlogPostCreateOrConnectWithoutAuthorInput]
+    create?: Array<NexusGenInputs['BlogPostCreateWithoutAuthorInput'] | null> | null; // [BlogPostCreateWithoutAuthorInput]
     createMany?: NexusGenInputs['BlogPostCreateManyAuthorInputEnvelope'] | null; // BlogPostCreateManyAuthorInputEnvelope
-    delete?: NexusGenInputs['BlogPostWhereUniqueInput'][] | null; // [BlogPostWhereUniqueInput!]
-    deleteMany?: NexusGenInputs['BlogPostScalarWhereInput'][] | null; // [BlogPostScalarWhereInput!]
-    disconnect?: NexusGenInputs['BlogPostWhereUniqueInput'][] | null; // [BlogPostWhereUniqueInput!]
-    set?: NexusGenInputs['BlogPostWhereUniqueInput'][] | null; // [BlogPostWhereUniqueInput!]
-    update?: NexusGenInputs['BlogPostUpdateWithWhereUniqueWithoutAuthorInput'][] | null; // [BlogPostUpdateWithWhereUniqueWithoutAuthorInput!]
-    updateMany?: NexusGenInputs['BlogPostUpdateManyWithWhereWithoutAuthorInput'][] | null; // [BlogPostUpdateManyWithWhereWithoutAuthorInput!]
-    upsert?: NexusGenInputs['BlogPostUpsertWithWhereUniqueWithoutAuthorInput'][] | null; // [BlogPostUpsertWithWhereUniqueWithoutAuthorInput!]
+    delete?: Array<NexusGenInputs['BlogPostWhereUniqueInput'] | null> | null; // [BlogPostWhereUniqueInput]
+    deleteMany?: Array<NexusGenInputs['BlogPostScalarWhereInput'] | null> | null; // [BlogPostScalarWhereInput]
+    set?: Array<NexusGenInputs['BlogPostWhereUniqueInput'] | null> | null; // [BlogPostWhereUniqueInput]
+    update?: Array<NexusGenInputs['BlogPostUpdateWithWhereUniqueWithoutAuthorInput'] | null> | null; // [BlogPostUpdateWithWhereUniqueWithoutAuthorInput]
+    updateMany?: Array<NexusGenInputs['BlogPostUpdateManyWithWhereWithoutAuthorInput'] | null> | null; // [BlogPostUpdateManyWithWhereWithoutAuthorInput]
+    upsert?: Array<NexusGenInputs['BlogPostUpsertWithWhereUniqueWithoutAuthorInput'] | null> | null; // [BlogPostUpsertWithWhereUniqueWithoutAuthorInput]
   }
   BlogPostUpdateOneWithoutCommentsInput: { // input type
     connect?: NexusGenInputs['BlogPostWhereUniqueInput'] | null; // BlogPostWhereUniqueInput
@@ -295,8 +294,8 @@ export interface NexusGenInputs {
     upsert?: NexusGenInputs['BlogPostUpsertWithoutCommentsInput'] | null; // BlogPostUpsertWithoutCommentsInput
   }
   BlogPostUpdateWithWhereUniqueWithoutAuthorInput: { // input type
-    data: NexusGenInputs['BlogPostUpdateWithoutAuthorInput']; // BlogPostUpdateWithoutAuthorInput!
-    where: NexusGenInputs['BlogPostWhereUniqueInput']; // BlogPostWhereUniqueInput!
+    data?: NexusGenInputs['BlogPostUpdateWithoutAuthorInput'] | null; // BlogPostUpdateWithoutAuthorInput
+    where?: NexusGenInputs['BlogPostWhereUniqueInput'] | null; // BlogPostWhereUniqueInput
   }
   BlogPostUpdateWithoutAuthorInput: { // input type
     comments?: NexusGenInputs['BlogPostCommentUpdateManyWithoutPostInput'] | null; // BlogPostCommentUpdateManyWithoutPostInput
@@ -311,9 +310,9 @@ export interface NexusGenInputs {
     title?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
   }
   BlogPostUpsertWithWhereUniqueWithoutAuthorInput: { // input type
-    create: NexusGenInputs['BlogPostCreateWithoutAuthorInput']; // BlogPostCreateWithoutAuthorInput!
-    update: NexusGenInputs['BlogPostUpdateWithoutAuthorInput']; // BlogPostUpdateWithoutAuthorInput!
-    where: NexusGenInputs['BlogPostWhereUniqueInput']; // BlogPostWhereUniqueInput!
+    create?: NexusGenInputs['BlogPostCreateWithoutAuthorInput'] | null; // BlogPostCreateWithoutAuthorInput
+    update?: NexusGenInputs['BlogPostUpdateWithoutAuthorInput'] | null; // BlogPostUpdateWithoutAuthorInput
+    where?: NexusGenInputs['BlogPostWhereUniqueInput'] | null; // BlogPostWhereUniqueInput
   }
   BlogPostUpsertWithoutCommentsInput: { // input type
     create: NexusGenInputs['BlogPostCreateWithoutCommentsInput']; // BlogPostCreateWithoutCommentsInput!
@@ -339,6 +338,53 @@ export interface NexusGenInputs {
   BoolFilter: { // input type
     equals?: boolean | null; // Boolean
     not?: NexusGenInputs['NestedBoolFilter'] | null; // NestedBoolFilter
+  }
+  CatCreateNestedOneWithoutOwnerInput: { // input type
+    connect?: NexusGenInputs['CatWhereUniqueInput'] | null; // CatWhereUniqueInput
+    connectOrCreate?: NexusGenInputs['CatCreateOrConnectWithoutOwnerInput'] | null; // CatCreateOrConnectWithoutOwnerInput
+    create?: NexusGenInputs['CatCreateWithoutOwnerInput'] | null; // CatCreateWithoutOwnerInput
+  }
+  CatCreateOrConnectWithoutOwnerInput: { // input type
+    create: NexusGenInputs['CatCreateWithoutOwnerInput']; // CatCreateWithoutOwnerInput!
+    where: NexusGenInputs['CatWhereUniqueInput']; // CatWhereUniqueInput!
+  }
+  CatCreateWithoutOwnerInput: { // input type
+    id?: string | null; // String
+    name: string; // String!
+  }
+  CatOrderByWithRelationInput: { // input type
+    id?: NexusGenEnums['SortOrder'] | null; // SortOrder
+    name?: NexusGenEnums['SortOrder'] | null; // SortOrder
+    owner?: NexusGenInputs['UserOrderByWithRelationInput'] | null; // UserOrderByWithRelationInput
+    userId?: NexusGenEnums['SortOrder'] | null; // SortOrder
+  }
+  CatUpdateOneWithoutOwnerInput: { // input type
+    connect?: NexusGenInputs['CatWhereUniqueInput'] | null; // CatWhereUniqueInput
+    connectOrCreate?: NexusGenInputs['CatCreateOrConnectWithoutOwnerInput'] | null; // CatCreateOrConnectWithoutOwnerInput
+    create?: NexusGenInputs['CatCreateWithoutOwnerInput'] | null; // CatCreateWithoutOwnerInput
+    delete?: boolean | null; // Boolean
+    update?: NexusGenInputs['CatUpdateWithoutOwnerInput'] | null; // CatUpdateWithoutOwnerInput
+    upsert?: NexusGenInputs['CatUpsertWithoutOwnerInput'] | null; // CatUpsertWithoutOwnerInput
+  }
+  CatUpdateWithoutOwnerInput: { // input type
+    id?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
+    name?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
+  }
+  CatUpsertWithoutOwnerInput: { // input type
+    create?: NexusGenInputs['CatCreateWithoutOwnerInput'] | null; // CatCreateWithoutOwnerInput
+    update?: NexusGenInputs['CatUpdateWithoutOwnerInput'] | null; // CatUpdateWithoutOwnerInput
+  }
+  CatWhereInput: { // input type
+    AND?: NexusGenInputs['CatWhereInput'][] | null; // [CatWhereInput!]
+    NOT?: NexusGenInputs['CatWhereInput'][] | null; // [CatWhereInput!]
+    OR?: NexusGenInputs['CatWhereInput'][] | null; // [CatWhereInput!]
+    id?: NexusGenInputs['StringFilter'] | null; // StringFilter
+    name?: NexusGenInputs['StringFilter'] | null; // StringFilter
+    owner?: NexusGenInputs['UserWhereInput'] | null; // UserWhereInput
+    userId?: NexusGenInputs['StringNullableFilter'] | null; // StringNullableFilter
+  }
+  CatWhereUniqueInput: { // input type
+    id?: string | null; // String
   }
   CompanyCreateInput: { // input type
     id?: string | null; // String
@@ -746,6 +792,7 @@ export interface NexusGenInputs {
   UserCreateInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCreateNestedManyWithoutAuthorInput
+    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyCreateNestedManyWithoutUserInput'] | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
@@ -801,6 +848,7 @@ export interface NexusGenInputs {
   }
   UserCreateWithoutBlogPostsInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
+    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyCreateNestedManyWithoutUserInput'] | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
@@ -818,6 +866,7 @@ export interface NexusGenInputs {
   UserCreateWithoutCommentsInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCreateNestedManyWithoutAuthorInput
+    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     companies?: NexusGenInputs['CompanyCreateNestedManyWithoutUserInput'] | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
     firstName?: string | null; // String
@@ -834,6 +883,7 @@ export interface NexusGenInputs {
   UserCreateWithoutCompaniesInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCreateNestedManyWithoutAuthorInput
+    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
     email: string; // String!
     firstName?: string | null; // String
@@ -850,6 +900,7 @@ export interface NexusGenInputs {
   UserCreateWithoutRolesInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCreateNestedManyWithoutAuthorInput
+    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyCreateNestedManyWithoutUserInput'] | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
@@ -877,6 +928,7 @@ export interface NexusGenInputs {
   UserOrderByWithRelationInput: { // input type
     address?: NexusGenEnums['SortOrder'] | null; // SortOrder
     blogPosts?: NexusGenInputs['BlogPostOrderByRelationAggregateInput'] | null; // BlogPostOrderByRelationAggregateInput
+    cat?: NexusGenInputs['CatOrderByWithRelationInput'] | null; // CatOrderByWithRelationInput
     comments?: NexusGenInputs['BlogPostCommentOrderByRelationAggregateInput'] | null; // BlogPostCommentOrderByRelationAggregateInput
     companies?: NexusGenInputs['CompanyOrderByRelationAggregateInput'] | null; // CompanyOrderByRelationAggregateInput
     email?: NexusGenEnums['SortOrder'] | null; // SortOrder
@@ -1048,6 +1100,7 @@ export interface NexusGenInputs {
   UserUpdateInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostUpdateManyWithoutAuthorInput'] | null; // BlogPostUpdateManyWithoutAuthorInput
+    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentUpdateManyWithoutAuthorInput'] | null; // BlogPostCommentUpdateManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyUpdateManyWithoutUserInput'] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
@@ -1121,6 +1174,7 @@ export interface NexusGenInputs {
   }
   UserUpdateWithoutBlogPostsInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
+    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentUpdateManyWithoutAuthorInput'] | null; // BlogPostCommentUpdateManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyUpdateManyWithoutUserInput'] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
@@ -1138,6 +1192,7 @@ export interface NexusGenInputs {
   UserUpdateWithoutCommentsInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostUpdateManyWithoutAuthorInput'] | null; // BlogPostUpdateManyWithoutAuthorInput
+    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     companies?: NexusGenInputs['CompanyUpdateManyWithoutUserInput'] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
     firstName?: NexusGenInputs['NullableStringFieldUpdateOperationsInput'] | null; // NullableStringFieldUpdateOperationsInput
@@ -1154,6 +1209,7 @@ export interface NexusGenInputs {
   UserUpdateWithoutCompaniesInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostUpdateManyWithoutAuthorInput'] | null; // BlogPostUpdateManyWithoutAuthorInput
+    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentUpdateManyWithoutAuthorInput'] | null; // BlogPostCommentUpdateManyWithoutAuthorInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
     firstName?: NexusGenInputs['NullableStringFieldUpdateOperationsInput'] | null; // NullableStringFieldUpdateOperationsInput
@@ -1170,6 +1226,7 @@ export interface NexusGenInputs {
   UserUpdateWithoutRolesInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostUpdateManyWithoutAuthorInput'] | null; // BlogPostUpdateManyWithoutAuthorInput
+    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentUpdateManyWithoutAuthorInput'] | null; // BlogPostCommentUpdateManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyUpdateManyWithoutUserInput'] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
@@ -1210,6 +1267,7 @@ export interface NexusGenInputs {
     OR?: NexusGenInputs['UserWhereInput'][] | null; // [UserWhereInput!]
     address?: NexusGenInputs['JsonNullableFilter'] | null; // JsonNullableFilter
     blogPosts?: NexusGenInputs['BlogPostListRelationFilter'] | null; // BlogPostListRelationFilter
+    cat?: NexusGenInputs['CatWhereInput'] | null; // CatWhereInput
     comments?: NexusGenInputs['BlogPostCommentListRelationFilter'] | null; // BlogPostCommentListRelationFilter
     companies?: NexusGenInputs['CompanyListRelationFilter'] | null; // CompanyListRelationFilter
     email?: NexusGenInputs['StringFilter'] | null; // StringFilter

--- a/packages/dataprovider/generated/nexus.ts
+++ b/packages/dataprovider/generated/nexus.ts
@@ -339,53 +339,6 @@ export interface NexusGenInputs {
     equals?: boolean | null; // Boolean
     not?: NexusGenInputs['NestedBoolFilter'] | null; // NestedBoolFilter
   }
-  CatCreateNestedOneWithoutOwnerInput: { // input type
-    connect?: NexusGenInputs['CatWhereUniqueInput'] | null; // CatWhereUniqueInput
-    connectOrCreate?: NexusGenInputs['CatCreateOrConnectWithoutOwnerInput'] | null; // CatCreateOrConnectWithoutOwnerInput
-    create?: NexusGenInputs['CatCreateWithoutOwnerInput'] | null; // CatCreateWithoutOwnerInput
-  }
-  CatCreateOrConnectWithoutOwnerInput: { // input type
-    create: NexusGenInputs['CatCreateWithoutOwnerInput']; // CatCreateWithoutOwnerInput!
-    where: NexusGenInputs['CatWhereUniqueInput']; // CatWhereUniqueInput!
-  }
-  CatCreateWithoutOwnerInput: { // input type
-    id?: string | null; // String
-    name: string; // String!
-  }
-  CatOrderByWithRelationInput: { // input type
-    id?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    name?: NexusGenEnums['SortOrder'] | null; // SortOrder
-    owner?: NexusGenInputs['UserOrderByWithRelationInput'] | null; // UserOrderByWithRelationInput
-    userId?: NexusGenEnums['SortOrder'] | null; // SortOrder
-  }
-  CatUpdateOneWithoutOwnerInput: { // input type
-    connect?: NexusGenInputs['CatWhereUniqueInput'] | null; // CatWhereUniqueInput
-    connectOrCreate?: NexusGenInputs['CatCreateOrConnectWithoutOwnerInput'] | null; // CatCreateOrConnectWithoutOwnerInput
-    create?: NexusGenInputs['CatCreateWithoutOwnerInput'] | null; // CatCreateWithoutOwnerInput
-    delete?: boolean | null; // Boolean
-    update?: NexusGenInputs['CatUpdateWithoutOwnerInput'] | null; // CatUpdateWithoutOwnerInput
-    upsert?: NexusGenInputs['CatUpsertWithoutOwnerInput'] | null; // CatUpsertWithoutOwnerInput
-  }
-  CatUpdateWithoutOwnerInput: { // input type
-    id?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
-    name?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
-  }
-  CatUpsertWithoutOwnerInput: { // input type
-    create?: NexusGenInputs['CatCreateWithoutOwnerInput'] | null; // CatCreateWithoutOwnerInput
-    update?: NexusGenInputs['CatUpdateWithoutOwnerInput'] | null; // CatUpdateWithoutOwnerInput
-  }
-  CatWhereInput: { // input type
-    AND?: NexusGenInputs['CatWhereInput'][] | null; // [CatWhereInput!]
-    NOT?: NexusGenInputs['CatWhereInput'][] | null; // [CatWhereInput!]
-    OR?: NexusGenInputs['CatWhereInput'][] | null; // [CatWhereInput!]
-    id?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    name?: NexusGenInputs['StringFilter'] | null; // StringFilter
-    owner?: NexusGenInputs['UserWhereInput'] | null; // UserWhereInput
-    userId?: NexusGenInputs['StringNullableFilter'] | null; // StringNullableFilter
-  }
-  CatWhereUniqueInput: { // input type
-    id?: string | null; // String
-  }
   CompanyCreateInput: { // input type
     id?: string | null; // String
     name: string; // String!
@@ -735,6 +688,57 @@ export interface NexusGenInputs {
   NullableStringFieldUpdateOperationsInput: { // input type
     set?: string | null; // String
   }
+  SiteCreateNestedOneWithoutOwnerInput: { // input type
+    connect?: NexusGenInputs['SiteWhereUniqueInput'] | null; // SiteWhereUniqueInput
+    connectOrCreate?: NexusGenInputs['SiteCreateOrConnectWithoutOwnerInput'] | null; // SiteCreateOrConnectWithoutOwnerInput
+    create?: NexusGenInputs['SiteCreateWithoutOwnerInput'] | null; // SiteCreateWithoutOwnerInput
+  }
+  SiteCreateOrConnectWithoutOwnerInput: { // input type
+    create: NexusGenInputs['SiteCreateWithoutOwnerInput']; // SiteCreateWithoutOwnerInput!
+    where: NexusGenInputs['SiteWhereUniqueInput']; // SiteWhereUniqueInput!
+  }
+  SiteCreateWithoutOwnerInput: { // input type
+    id?: string | null; // String
+    name: string; // String!
+    url: string; // String!
+  }
+  SiteOrderByWithRelationInput: { // input type
+    id?: NexusGenEnums['SortOrder'] | null; // SortOrder
+    name?: NexusGenEnums['SortOrder'] | null; // SortOrder
+    owner?: NexusGenInputs['UserOrderByWithRelationInput'] | null; // UserOrderByWithRelationInput
+    url?: NexusGenEnums['SortOrder'] | null; // SortOrder
+    userId?: NexusGenEnums['SortOrder'] | null; // SortOrder
+  }
+  SiteUpdateOneWithoutOwnerInput: { // input type
+    connect?: NexusGenInputs['SiteWhereUniqueInput'] | null; // SiteWhereUniqueInput
+    connectOrCreate?: NexusGenInputs['SiteCreateOrConnectWithoutOwnerInput'] | null; // SiteCreateOrConnectWithoutOwnerInput
+    create?: NexusGenInputs['SiteCreateWithoutOwnerInput'] | null; // SiteCreateWithoutOwnerInput
+    delete?: boolean | null; // Boolean
+    update?: NexusGenInputs['SiteUpdateWithoutOwnerInput'] | null; // SiteUpdateWithoutOwnerInput
+    upsert?: NexusGenInputs['SiteUpsertWithoutOwnerInput'] | null; // SiteUpsertWithoutOwnerInput
+  }
+  SiteUpdateWithoutOwnerInput: { // input type
+    id?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
+    name?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
+    url?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
+  }
+  SiteUpsertWithoutOwnerInput: { // input type
+    create?: NexusGenInputs['SiteCreateWithoutOwnerInput'] | null; // SiteCreateWithoutOwnerInput
+    update?: NexusGenInputs['SiteUpdateWithoutOwnerInput'] | null; // SiteUpdateWithoutOwnerInput
+  }
+  SiteWhereInput: { // input type
+    AND?: NexusGenInputs['SiteWhereInput'][] | null; // [SiteWhereInput!]
+    NOT?: NexusGenInputs['SiteWhereInput'][] | null; // [SiteWhereInput!]
+    OR?: NexusGenInputs['SiteWhereInput'][] | null; // [SiteWhereInput!]
+    id?: NexusGenInputs['StringFilter'] | null; // StringFilter
+    name?: NexusGenInputs['StringFilter'] | null; // StringFilter
+    owner?: NexusGenInputs['UserWhereInput'] | null; // UserWhereInput
+    url?: NexusGenInputs['StringFilter'] | null; // StringFilter
+    userId?: NexusGenInputs['StringNullableFilter'] | null; // StringNullableFilter
+  }
+  SiteWhereUniqueInput: { // input type
+    id?: string | null; // String
+  }
   SomePublicRecordWithIntIdCreateInput: { // input type
     title: string; // String!
   }
@@ -792,7 +796,6 @@ export interface NexusGenInputs {
   UserCreateInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCreateNestedManyWithoutAuthorInput
-    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyCreateNestedManyWithoutUserInput'] | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
@@ -802,6 +805,7 @@ export interface NexusGenInputs {
     interests?: NexusGenInputs['UserCreateinterestsInput'] | null; // UserCreateinterestsInput
     lastName?: string | null; // String
     roles?: NexusGenInputs['UserRoleCreateNestedManyWithoutUsersInput'] | null; // UserRoleCreateNestedManyWithoutUsersInput
+    site?: NexusGenInputs['SiteCreateNestedOneWithoutOwnerInput'] | null; // SiteCreateNestedOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaCreateNestedOneWithoutUserInput'] | null; // UserSocialMediaCreateNestedOneWithoutUserInput
     wantsNewsletter: boolean; // Boolean!
     weddingDate?: NexusGenScalars['DateTime'] | null; // DateTime
@@ -848,7 +852,6 @@ export interface NexusGenInputs {
   }
   UserCreateWithoutBlogPostsInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
-    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyCreateNestedManyWithoutUserInput'] | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
@@ -858,6 +861,7 @@ export interface NexusGenInputs {
     interests?: NexusGenInputs['UserCreateinterestsInput'] | null; // UserCreateinterestsInput
     lastName?: string | null; // String
     roles?: NexusGenInputs['UserRoleCreateNestedManyWithoutUsersInput'] | null; // UserRoleCreateNestedManyWithoutUsersInput
+    site?: NexusGenInputs['SiteCreateNestedOneWithoutOwnerInput'] | null; // SiteCreateNestedOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaCreateNestedOneWithoutUserInput'] | null; // UserSocialMediaCreateNestedOneWithoutUserInput
     wantsNewsletter: boolean; // Boolean!
     weddingDate?: NexusGenScalars['DateTime'] | null; // DateTime
@@ -866,7 +870,6 @@ export interface NexusGenInputs {
   UserCreateWithoutCommentsInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCreateNestedManyWithoutAuthorInput
-    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     companies?: NexusGenInputs['CompanyCreateNestedManyWithoutUserInput'] | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
     firstName?: string | null; // String
@@ -875,6 +878,7 @@ export interface NexusGenInputs {
     interests?: NexusGenInputs['UserCreateinterestsInput'] | null; // UserCreateinterestsInput
     lastName?: string | null; // String
     roles?: NexusGenInputs['UserRoleCreateNestedManyWithoutUsersInput'] | null; // UserRoleCreateNestedManyWithoutUsersInput
+    site?: NexusGenInputs['SiteCreateNestedOneWithoutOwnerInput'] | null; // SiteCreateNestedOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaCreateNestedOneWithoutUserInput'] | null; // UserSocialMediaCreateNestedOneWithoutUserInput
     wantsNewsletter: boolean; // Boolean!
     weddingDate?: NexusGenScalars['DateTime'] | null; // DateTime
@@ -883,7 +887,6 @@ export interface NexusGenInputs {
   UserCreateWithoutCompaniesInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCreateNestedManyWithoutAuthorInput
-    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
     email: string; // String!
     firstName?: string | null; // String
@@ -892,6 +895,7 @@ export interface NexusGenInputs {
     interests?: NexusGenInputs['UserCreateinterestsInput'] | null; // UserCreateinterestsInput
     lastName?: string | null; // String
     roles?: NexusGenInputs['UserRoleCreateNestedManyWithoutUsersInput'] | null; // UserRoleCreateNestedManyWithoutUsersInput
+    site?: NexusGenInputs['SiteCreateNestedOneWithoutOwnerInput'] | null; // SiteCreateNestedOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaCreateNestedOneWithoutUserInput'] | null; // UserSocialMediaCreateNestedOneWithoutUserInput
     wantsNewsletter: boolean; // Boolean!
     weddingDate?: NexusGenScalars['DateTime'] | null; // DateTime
@@ -900,7 +904,6 @@ export interface NexusGenInputs {
   UserCreateWithoutRolesInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCreateNestedManyWithoutAuthorInput
-    cat?: NexusGenInputs['CatCreateNestedOneWithoutOwnerInput'] | null; // CatCreateNestedOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentCreateNestedManyWithoutAuthorInput'] | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyCreateNestedManyWithoutUserInput'] | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
@@ -909,6 +912,7 @@ export interface NexusGenInputs {
     id?: string | null; // String
     interests?: NexusGenInputs['UserCreateinterestsInput'] | null; // UserCreateinterestsInput
     lastName?: string | null; // String
+    site?: NexusGenInputs['SiteCreateNestedOneWithoutOwnerInput'] | null; // SiteCreateNestedOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaCreateNestedOneWithoutUserInput'] | null; // UserSocialMediaCreateNestedOneWithoutUserInput
     wantsNewsletter: boolean; // Boolean!
     weddingDate?: NexusGenScalars['DateTime'] | null; // DateTime
@@ -928,7 +932,6 @@ export interface NexusGenInputs {
   UserOrderByWithRelationInput: { // input type
     address?: NexusGenEnums['SortOrder'] | null; // SortOrder
     blogPosts?: NexusGenInputs['BlogPostOrderByRelationAggregateInput'] | null; // BlogPostOrderByRelationAggregateInput
-    cat?: NexusGenInputs['CatOrderByWithRelationInput'] | null; // CatOrderByWithRelationInput
     comments?: NexusGenInputs['BlogPostCommentOrderByRelationAggregateInput'] | null; // BlogPostCommentOrderByRelationAggregateInput
     companies?: NexusGenInputs['CompanyOrderByRelationAggregateInput'] | null; // CompanyOrderByRelationAggregateInput
     email?: NexusGenEnums['SortOrder'] | null; // SortOrder
@@ -938,6 +941,7 @@ export interface NexusGenInputs {
     interests?: NexusGenEnums['SortOrder'] | null; // SortOrder
     lastName?: NexusGenEnums['SortOrder'] | null; // SortOrder
     roles?: NexusGenInputs['UserRoleOrderByRelationAggregateInput'] | null; // UserRoleOrderByRelationAggregateInput
+    site?: NexusGenInputs['SiteOrderByWithRelationInput'] | null; // SiteOrderByWithRelationInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaOrderByWithRelationInput'] | null; // UserSocialMediaOrderByWithRelationInput
     wantsNewsletter?: NexusGenEnums['SortOrder'] | null; // SortOrder
     weddingDate?: NexusGenEnums['SortOrder'] | null; // SortOrder
@@ -1100,7 +1104,6 @@ export interface NexusGenInputs {
   UserUpdateInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostUpdateManyWithoutAuthorInput'] | null; // BlogPostUpdateManyWithoutAuthorInput
-    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentUpdateManyWithoutAuthorInput'] | null; // BlogPostCommentUpdateManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyUpdateManyWithoutUserInput'] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
@@ -1110,6 +1113,7 @@ export interface NexusGenInputs {
     interests?: NexusGenInputs['UserUpdateinterestsInput'] | null; // UserUpdateinterestsInput
     lastName?: NexusGenInputs['NullableStringFieldUpdateOperationsInput'] | null; // NullableStringFieldUpdateOperationsInput
     roles?: NexusGenInputs['UserRoleUpdateManyWithoutUsersInput'] | null; // UserRoleUpdateManyWithoutUsersInput
+    site?: NexusGenInputs['SiteUpdateOneWithoutOwnerInput'] | null; // SiteUpdateOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaUpdateOneWithoutUserInput'] | null; // UserSocialMediaUpdateOneWithoutUserInput
     wantsNewsletter?: NexusGenInputs['BoolFieldUpdateOperationsInput'] | null; // BoolFieldUpdateOperationsInput
     weddingDate?: NexusGenInputs['NullableDateTimeFieldUpdateOperationsInput'] | null; // NullableDateTimeFieldUpdateOperationsInput
@@ -1174,7 +1178,6 @@ export interface NexusGenInputs {
   }
   UserUpdateWithoutBlogPostsInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
-    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentUpdateManyWithoutAuthorInput'] | null; // BlogPostCommentUpdateManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyUpdateManyWithoutUserInput'] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
@@ -1184,6 +1187,7 @@ export interface NexusGenInputs {
     interests?: NexusGenInputs['UserUpdateinterestsInput'] | null; // UserUpdateinterestsInput
     lastName?: NexusGenInputs['NullableStringFieldUpdateOperationsInput'] | null; // NullableStringFieldUpdateOperationsInput
     roles?: NexusGenInputs['UserRoleUpdateManyWithoutUsersInput'] | null; // UserRoleUpdateManyWithoutUsersInput
+    site?: NexusGenInputs['SiteUpdateOneWithoutOwnerInput'] | null; // SiteUpdateOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaUpdateOneWithoutUserInput'] | null; // UserSocialMediaUpdateOneWithoutUserInput
     wantsNewsletter?: NexusGenInputs['BoolFieldUpdateOperationsInput'] | null; // BoolFieldUpdateOperationsInput
     weddingDate?: NexusGenInputs['NullableDateTimeFieldUpdateOperationsInput'] | null; // NullableDateTimeFieldUpdateOperationsInput
@@ -1192,7 +1196,6 @@ export interface NexusGenInputs {
   UserUpdateWithoutCommentsInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostUpdateManyWithoutAuthorInput'] | null; // BlogPostUpdateManyWithoutAuthorInput
-    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     companies?: NexusGenInputs['CompanyUpdateManyWithoutUserInput'] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
     firstName?: NexusGenInputs['NullableStringFieldUpdateOperationsInput'] | null; // NullableStringFieldUpdateOperationsInput
@@ -1201,6 +1204,7 @@ export interface NexusGenInputs {
     interests?: NexusGenInputs['UserUpdateinterestsInput'] | null; // UserUpdateinterestsInput
     lastName?: NexusGenInputs['NullableStringFieldUpdateOperationsInput'] | null; // NullableStringFieldUpdateOperationsInput
     roles?: NexusGenInputs['UserRoleUpdateManyWithoutUsersInput'] | null; // UserRoleUpdateManyWithoutUsersInput
+    site?: NexusGenInputs['SiteUpdateOneWithoutOwnerInput'] | null; // SiteUpdateOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaUpdateOneWithoutUserInput'] | null; // UserSocialMediaUpdateOneWithoutUserInput
     wantsNewsletter?: NexusGenInputs['BoolFieldUpdateOperationsInput'] | null; // BoolFieldUpdateOperationsInput
     weddingDate?: NexusGenInputs['NullableDateTimeFieldUpdateOperationsInput'] | null; // NullableDateTimeFieldUpdateOperationsInput
@@ -1209,7 +1213,6 @@ export interface NexusGenInputs {
   UserUpdateWithoutCompaniesInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostUpdateManyWithoutAuthorInput'] | null; // BlogPostUpdateManyWithoutAuthorInput
-    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentUpdateManyWithoutAuthorInput'] | null; // BlogPostCommentUpdateManyWithoutAuthorInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
     firstName?: NexusGenInputs['NullableStringFieldUpdateOperationsInput'] | null; // NullableStringFieldUpdateOperationsInput
@@ -1218,6 +1221,7 @@ export interface NexusGenInputs {
     interests?: NexusGenInputs['UserUpdateinterestsInput'] | null; // UserUpdateinterestsInput
     lastName?: NexusGenInputs['NullableStringFieldUpdateOperationsInput'] | null; // NullableStringFieldUpdateOperationsInput
     roles?: NexusGenInputs['UserRoleUpdateManyWithoutUsersInput'] | null; // UserRoleUpdateManyWithoutUsersInput
+    site?: NexusGenInputs['SiteUpdateOneWithoutOwnerInput'] | null; // SiteUpdateOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaUpdateOneWithoutUserInput'] | null; // UserSocialMediaUpdateOneWithoutUserInput
     wantsNewsletter?: NexusGenInputs['BoolFieldUpdateOperationsInput'] | null; // BoolFieldUpdateOperationsInput
     weddingDate?: NexusGenInputs['NullableDateTimeFieldUpdateOperationsInput'] | null; // NullableDateTimeFieldUpdateOperationsInput
@@ -1226,7 +1230,6 @@ export interface NexusGenInputs {
   UserUpdateWithoutRolesInput: { // input type
     address?: NexusGenScalars['Json'] | null; // Json
     blogPosts?: NexusGenInputs['BlogPostUpdateManyWithoutAuthorInput'] | null; // BlogPostUpdateManyWithoutAuthorInput
-    cat?: NexusGenInputs['CatUpdateOneWithoutOwnerInput'] | null; // CatUpdateOneWithoutOwnerInput
     comments?: NexusGenInputs['BlogPostCommentUpdateManyWithoutAuthorInput'] | null; // BlogPostCommentUpdateManyWithoutAuthorInput
     companies?: NexusGenInputs['CompanyUpdateManyWithoutUserInput'] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
@@ -1235,6 +1238,7 @@ export interface NexusGenInputs {
     id?: NexusGenInputs['StringFieldUpdateOperationsInput'] | null; // StringFieldUpdateOperationsInput
     interests?: NexusGenInputs['UserUpdateinterestsInput'] | null; // UserUpdateinterestsInput
     lastName?: NexusGenInputs['NullableStringFieldUpdateOperationsInput'] | null; // NullableStringFieldUpdateOperationsInput
+    site?: NexusGenInputs['SiteUpdateOneWithoutOwnerInput'] | null; // SiteUpdateOneWithoutOwnerInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaUpdateOneWithoutUserInput'] | null; // UserSocialMediaUpdateOneWithoutUserInput
     wantsNewsletter?: NexusGenInputs['BoolFieldUpdateOperationsInput'] | null; // BoolFieldUpdateOperationsInput
     weddingDate?: NexusGenInputs['NullableDateTimeFieldUpdateOperationsInput'] | null; // NullableDateTimeFieldUpdateOperationsInput
@@ -1267,7 +1271,6 @@ export interface NexusGenInputs {
     OR?: NexusGenInputs['UserWhereInput'][] | null; // [UserWhereInput!]
     address?: NexusGenInputs['JsonNullableFilter'] | null; // JsonNullableFilter
     blogPosts?: NexusGenInputs['BlogPostListRelationFilter'] | null; // BlogPostListRelationFilter
-    cat?: NexusGenInputs['CatWhereInput'] | null; // CatWhereInput
     comments?: NexusGenInputs['BlogPostCommentListRelationFilter'] | null; // BlogPostCommentListRelationFilter
     companies?: NexusGenInputs['CompanyListRelationFilter'] | null; // CompanyListRelationFilter
     email?: NexusGenInputs['StringFilter'] | null; // StringFilter
@@ -1277,6 +1280,7 @@ export interface NexusGenInputs {
     interests?: NexusGenInputs['EnumTopicNullableListFilter'] | null; // EnumTopicNullableListFilter
     lastName?: NexusGenInputs['StringNullableFilter'] | null; // StringNullableFilter
     roles?: NexusGenInputs['UserRoleListRelationFilter'] | null; // UserRoleListRelationFilter
+    site?: NexusGenInputs['SiteWhereInput'] | null; // SiteWhereInput
     userSocialMedia?: NexusGenInputs['UserSocialMediaWhereInput'] | null; // UserSocialMediaWhereInput
     wantsNewsletter?: NexusGenInputs['BoolFilter'] | null; // BoolFilter
     weddingDate?: NexusGenInputs['DateTimeNullableFilter'] | null; // DateTimeNullableFilter

--- a/packages/dataprovider/generated/schema.graphql
+++ b/packages/dataprovider/generated/schema.graphql
@@ -297,9 +297,9 @@ input BlogPostOrderByWithRelationInput {
 }
 
 input BlogPostScalarWhereInput {
-  AND: [BlogPostScalarWhereInput!]
-  NOT: [BlogPostScalarWhereInput!]
-  OR: [BlogPostScalarWhereInput!]
+  AND: [BlogPostScalarWhereInput]
+  NOT: [BlogPostScalarWhereInput]
+  OR: [BlogPostScalarWhereInput]
   authorId: StringNullableFilter
   id: StringFilter
   text: StringFilter
@@ -321,22 +321,21 @@ input BlogPostUpdateManyMutationInput {
 }
 
 input BlogPostUpdateManyWithWhereWithoutAuthorInput {
-  data: BlogPostUpdateManyMutationInput!
-  where: BlogPostScalarWhereInput!
+  data: BlogPostUpdateManyMutationInput
+  where: BlogPostScalarWhereInput
 }
 
 input BlogPostUpdateManyWithoutAuthorInput {
-  connect: [BlogPostWhereUniqueInput!]
-  connectOrCreate: [BlogPostCreateOrConnectWithoutAuthorInput!]
-  create: [BlogPostCreateWithoutAuthorInput!]
+  connect: [BlogPostWhereUniqueInput]
+  connectOrCreate: [BlogPostCreateOrConnectWithoutAuthorInput]
+  create: [BlogPostCreateWithoutAuthorInput]
   createMany: BlogPostCreateManyAuthorInputEnvelope
-  delete: [BlogPostWhereUniqueInput!]
-  deleteMany: [BlogPostScalarWhereInput!]
-  disconnect: [BlogPostWhereUniqueInput!]
-  set: [BlogPostWhereUniqueInput!]
-  update: [BlogPostUpdateWithWhereUniqueWithoutAuthorInput!]
-  updateMany: [BlogPostUpdateManyWithWhereWithoutAuthorInput!]
-  upsert: [BlogPostUpsertWithWhereUniqueWithoutAuthorInput!]
+  delete: [BlogPostWhereUniqueInput]
+  deleteMany: [BlogPostScalarWhereInput]
+  set: [BlogPostWhereUniqueInput]
+  update: [BlogPostUpdateWithWhereUniqueWithoutAuthorInput]
+  updateMany: [BlogPostUpdateManyWithWhereWithoutAuthorInput]
+  upsert: [BlogPostUpsertWithWhereUniqueWithoutAuthorInput]
 }
 
 input BlogPostUpdateOneWithoutCommentsInput {
@@ -350,8 +349,8 @@ input BlogPostUpdateOneWithoutCommentsInput {
 }
 
 input BlogPostUpdateWithWhereUniqueWithoutAuthorInput {
-  data: BlogPostUpdateWithoutAuthorInput!
-  where: BlogPostWhereUniqueInput!
+  data: BlogPostUpdateWithoutAuthorInput
+  where: BlogPostWhereUniqueInput
 }
 
 input BlogPostUpdateWithoutAuthorInput {
@@ -369,9 +368,9 @@ input BlogPostUpdateWithoutCommentsInput {
 }
 
 input BlogPostUpsertWithWhereUniqueWithoutAuthorInput {
-  create: BlogPostCreateWithoutAuthorInput!
-  update: BlogPostUpdateWithoutAuthorInput!
-  where: BlogPostWhereUniqueInput!
+  create: BlogPostCreateWithoutAuthorInput
+  update: BlogPostUpdateWithoutAuthorInput
+  where: BlogPostWhereUniqueInput
 }
 
 input BlogPostUpsertWithoutCommentsInput {
@@ -402,6 +401,62 @@ input BoolFieldUpdateOperationsInput {
 input BoolFilter {
   equals: Boolean
   not: NestedBoolFilter
+}
+
+input CatCreateNestedOneWithoutOwnerInput {
+  connect: CatWhereUniqueInput
+  connectOrCreate: CatCreateOrConnectWithoutOwnerInput
+  create: CatCreateWithoutOwnerInput
+}
+
+input CatCreateOrConnectWithoutOwnerInput {
+  create: CatCreateWithoutOwnerInput!
+  where: CatWhereUniqueInput!
+}
+
+input CatCreateWithoutOwnerInput {
+  id: String
+  name: String!
+}
+
+input CatOrderByWithRelationInput {
+  id: SortOrder
+  name: SortOrder
+  owner: UserOrderByWithRelationInput
+  userId: SortOrder
+}
+
+input CatUpdateOneWithoutOwnerInput {
+  connect: CatWhereUniqueInput
+  connectOrCreate: CatCreateOrConnectWithoutOwnerInput
+  create: CatCreateWithoutOwnerInput
+  delete: Boolean
+  update: CatUpdateWithoutOwnerInput
+  upsert: CatUpsertWithoutOwnerInput
+}
+
+input CatUpdateWithoutOwnerInput {
+  id: StringFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+}
+
+input CatUpsertWithoutOwnerInput {
+  create: CatCreateWithoutOwnerInput
+  update: CatUpdateWithoutOwnerInput
+}
+
+input CatWhereInput {
+  AND: [CatWhereInput!]
+  NOT: [CatWhereInput!]
+  OR: [CatWhereInput!]
+  id: StringFilter
+  name: StringFilter
+  owner: UserWhereInput
+  userId: StringNullableFilter
+}
+
+input CatWhereUniqueInput {
+  id: String
 }
 
 type Company {
@@ -1005,6 +1060,7 @@ type User {
 input UserCreateInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
+  cat: CatCreateNestedOneWithoutOwnerInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
   companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
@@ -1070,6 +1126,7 @@ input UserCreateOrConnectWithoutRolesInput {
 
 input UserCreateWithoutBlogPostsInput {
   address: Json
+  cat: CatCreateNestedOneWithoutOwnerInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
   companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
@@ -1088,6 +1145,7 @@ input UserCreateWithoutBlogPostsInput {
 input UserCreateWithoutCommentsInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
+  cat: CatCreateNestedOneWithoutOwnerInput
   companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
   firstName: String
@@ -1105,6 +1163,7 @@ input UserCreateWithoutCommentsInput {
 input UserCreateWithoutCompaniesInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
+  cat: CatCreateNestedOneWithoutOwnerInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
   email: String!
   firstName: String
@@ -1122,6 +1181,7 @@ input UserCreateWithoutCompaniesInput {
 input UserCreateWithoutRolesInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
+  cat: CatCreateNestedOneWithoutOwnerInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
   companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
@@ -1153,6 +1213,7 @@ input UserOrderByRelationAggregateInput {
 input UserOrderByWithRelationInput {
   address: SortOrder
   blogPosts: BlogPostOrderByRelationAggregateInput
+  cat: CatOrderByWithRelationInput
   comments: BlogPostCommentOrderByRelationAggregateInput
   companies: CompanyOrderByRelationAggregateInput
   email: SortOrder
@@ -1364,6 +1425,7 @@ input UserSocialMediaWhereUniqueInput {
 input UserUpdateInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
+  cat: CatUpdateOneWithoutOwnerInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
   companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
@@ -1445,6 +1507,7 @@ input UserUpdateWithWhereUniqueWithoutRolesInput {
 
 input UserUpdateWithoutBlogPostsInput {
   address: Json
+  cat: CatUpdateOneWithoutOwnerInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
   companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
@@ -1463,6 +1526,7 @@ input UserUpdateWithoutBlogPostsInput {
 input UserUpdateWithoutCommentsInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
+  cat: CatUpdateOneWithoutOwnerInput
   companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
   firstName: NullableStringFieldUpdateOperationsInput
@@ -1480,6 +1544,7 @@ input UserUpdateWithoutCommentsInput {
 input UserUpdateWithoutCompaniesInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
+  cat: CatUpdateOneWithoutOwnerInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
   email: StringFieldUpdateOperationsInput
   firstName: NullableStringFieldUpdateOperationsInput
@@ -1497,6 +1562,7 @@ input UserUpdateWithoutCompaniesInput {
 input UserUpdateWithoutRolesInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
+  cat: CatUpdateOneWithoutOwnerInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
   companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
@@ -1543,6 +1609,7 @@ input UserWhereInput {
   OR: [UserWhereInput!]
   address: JsonNullableFilter
   blogPosts: BlogPostListRelationFilter
+  cat: CatWhereInput
   comments: BlogPostCommentListRelationFilter
   companies: CompanyListRelationFilter
   email: StringFilter

--- a/packages/dataprovider/generated/schema.graphql
+++ b/packages/dataprovider/generated/schema.graphql
@@ -403,62 +403,6 @@ input BoolFilter {
   not: NestedBoolFilter
 }
 
-input CatCreateNestedOneWithoutOwnerInput {
-  connect: CatWhereUniqueInput
-  connectOrCreate: CatCreateOrConnectWithoutOwnerInput
-  create: CatCreateWithoutOwnerInput
-}
-
-input CatCreateOrConnectWithoutOwnerInput {
-  create: CatCreateWithoutOwnerInput!
-  where: CatWhereUniqueInput!
-}
-
-input CatCreateWithoutOwnerInput {
-  id: String
-  name: String!
-}
-
-input CatOrderByWithRelationInput {
-  id: SortOrder
-  name: SortOrder
-  owner: UserOrderByWithRelationInput
-  userId: SortOrder
-}
-
-input CatUpdateOneWithoutOwnerInput {
-  connect: CatWhereUniqueInput
-  connectOrCreate: CatCreateOrConnectWithoutOwnerInput
-  create: CatCreateWithoutOwnerInput
-  delete: Boolean
-  update: CatUpdateWithoutOwnerInput
-  upsert: CatUpsertWithoutOwnerInput
-}
-
-input CatUpdateWithoutOwnerInput {
-  id: StringFieldUpdateOperationsInput
-  name: StringFieldUpdateOperationsInput
-}
-
-input CatUpsertWithoutOwnerInput {
-  create: CatCreateWithoutOwnerInput
-  update: CatUpdateWithoutOwnerInput
-}
-
-input CatWhereInput {
-  AND: [CatWhereInput!]
-  NOT: [CatWhereInput!]
-  OR: [CatWhereInput!]
-  id: StringFilter
-  name: StringFilter
-  owner: UserWhereInput
-  userId: StringNullableFilter
-}
-
-input CatWhereUniqueInput {
-  id: String
-}
-
 type Company {
   id: String!
   name: String!
@@ -959,6 +903,66 @@ enum QueryMode {
   insensitive
 }
 
+input SiteCreateNestedOneWithoutOwnerInput {
+  connect: SiteWhereUniqueInput
+  connectOrCreate: SiteCreateOrConnectWithoutOwnerInput
+  create: SiteCreateWithoutOwnerInput
+}
+
+input SiteCreateOrConnectWithoutOwnerInput {
+  create: SiteCreateWithoutOwnerInput!
+  where: SiteWhereUniqueInput!
+}
+
+input SiteCreateWithoutOwnerInput {
+  id: String
+  name: String!
+  url: String!
+}
+
+input SiteOrderByWithRelationInput {
+  id: SortOrder
+  name: SortOrder
+  owner: UserOrderByWithRelationInput
+  url: SortOrder
+  userId: SortOrder
+}
+
+input SiteUpdateOneWithoutOwnerInput {
+  connect: SiteWhereUniqueInput
+  connectOrCreate: SiteCreateOrConnectWithoutOwnerInput
+  create: SiteCreateWithoutOwnerInput
+  delete: Boolean
+  update: SiteUpdateWithoutOwnerInput
+  upsert: SiteUpsertWithoutOwnerInput
+}
+
+input SiteUpdateWithoutOwnerInput {
+  id: StringFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+  url: StringFieldUpdateOperationsInput
+}
+
+input SiteUpsertWithoutOwnerInput {
+  create: SiteCreateWithoutOwnerInput
+  update: SiteUpdateWithoutOwnerInput
+}
+
+input SiteWhereInput {
+  AND: [SiteWhereInput!]
+  NOT: [SiteWhereInput!]
+  OR: [SiteWhereInput!]
+  id: StringFilter
+  name: StringFilter
+  owner: UserWhereInput
+  url: StringFilter
+  userId: StringNullableFilter
+}
+
+input SiteWhereUniqueInput {
+  id: String
+}
+
 type SomePublicRecordWithIntId {
   id: Int!
   title: String!
@@ -1060,7 +1064,6 @@ type User {
 input UserCreateInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
-  cat: CatCreateNestedOneWithoutOwnerInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
   companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
@@ -1070,6 +1073,7 @@ input UserCreateInput {
   interests: UserCreateinterestsInput
   lastName: String
   roles: UserRoleCreateNestedManyWithoutUsersInput
+  site: SiteCreateNestedOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaCreateNestedOneWithoutUserInput
   wantsNewsletter: Boolean!
   weddingDate: DateTime
@@ -1126,7 +1130,6 @@ input UserCreateOrConnectWithoutRolesInput {
 
 input UserCreateWithoutBlogPostsInput {
   address: Json
-  cat: CatCreateNestedOneWithoutOwnerInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
   companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
@@ -1136,6 +1139,7 @@ input UserCreateWithoutBlogPostsInput {
   interests: UserCreateinterestsInput
   lastName: String
   roles: UserRoleCreateNestedManyWithoutUsersInput
+  site: SiteCreateNestedOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaCreateNestedOneWithoutUserInput
   wantsNewsletter: Boolean!
   weddingDate: DateTime
@@ -1145,7 +1149,6 @@ input UserCreateWithoutBlogPostsInput {
 input UserCreateWithoutCommentsInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
-  cat: CatCreateNestedOneWithoutOwnerInput
   companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
   firstName: String
@@ -1154,6 +1157,7 @@ input UserCreateWithoutCommentsInput {
   interests: UserCreateinterestsInput
   lastName: String
   roles: UserRoleCreateNestedManyWithoutUsersInput
+  site: SiteCreateNestedOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaCreateNestedOneWithoutUserInput
   wantsNewsletter: Boolean!
   weddingDate: DateTime
@@ -1163,7 +1167,6 @@ input UserCreateWithoutCommentsInput {
 input UserCreateWithoutCompaniesInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
-  cat: CatCreateNestedOneWithoutOwnerInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
   email: String!
   firstName: String
@@ -1172,6 +1175,7 @@ input UserCreateWithoutCompaniesInput {
   interests: UserCreateinterestsInput
   lastName: String
   roles: UserRoleCreateNestedManyWithoutUsersInput
+  site: SiteCreateNestedOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaCreateNestedOneWithoutUserInput
   wantsNewsletter: Boolean!
   weddingDate: DateTime
@@ -1181,7 +1185,6 @@ input UserCreateWithoutCompaniesInput {
 input UserCreateWithoutRolesInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
-  cat: CatCreateNestedOneWithoutOwnerInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
   companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
@@ -1190,6 +1193,7 @@ input UserCreateWithoutRolesInput {
   id: String
   interests: UserCreateinterestsInput
   lastName: String
+  site: SiteCreateNestedOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaCreateNestedOneWithoutUserInput
   wantsNewsletter: Boolean!
   weddingDate: DateTime
@@ -1213,7 +1217,6 @@ input UserOrderByRelationAggregateInput {
 input UserOrderByWithRelationInput {
   address: SortOrder
   blogPosts: BlogPostOrderByRelationAggregateInput
-  cat: CatOrderByWithRelationInput
   comments: BlogPostCommentOrderByRelationAggregateInput
   companies: CompanyOrderByRelationAggregateInput
   email: SortOrder
@@ -1223,6 +1226,7 @@ input UserOrderByWithRelationInput {
   interests: SortOrder
   lastName: SortOrder
   roles: UserRoleOrderByRelationAggregateInput
+  site: SiteOrderByWithRelationInput
   userSocialMedia: UserSocialMediaOrderByWithRelationInput
   wantsNewsletter: SortOrder
   weddingDate: SortOrder
@@ -1425,7 +1429,6 @@ input UserSocialMediaWhereUniqueInput {
 input UserUpdateInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
-  cat: CatUpdateOneWithoutOwnerInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
   companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
@@ -1435,6 +1438,7 @@ input UserUpdateInput {
   interests: UserUpdateinterestsInput
   lastName: NullableStringFieldUpdateOperationsInput
   roles: UserRoleUpdateManyWithoutUsersInput
+  site: SiteUpdateOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaUpdateOneWithoutUserInput
   wantsNewsletter: BoolFieldUpdateOperationsInput
   weddingDate: NullableDateTimeFieldUpdateOperationsInput
@@ -1507,7 +1511,6 @@ input UserUpdateWithWhereUniqueWithoutRolesInput {
 
 input UserUpdateWithoutBlogPostsInput {
   address: Json
-  cat: CatUpdateOneWithoutOwnerInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
   companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
@@ -1517,6 +1520,7 @@ input UserUpdateWithoutBlogPostsInput {
   interests: UserUpdateinterestsInput
   lastName: NullableStringFieldUpdateOperationsInput
   roles: UserRoleUpdateManyWithoutUsersInput
+  site: SiteUpdateOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaUpdateOneWithoutUserInput
   wantsNewsletter: BoolFieldUpdateOperationsInput
   weddingDate: NullableDateTimeFieldUpdateOperationsInput
@@ -1526,7 +1530,6 @@ input UserUpdateWithoutBlogPostsInput {
 input UserUpdateWithoutCommentsInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
-  cat: CatUpdateOneWithoutOwnerInput
   companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
   firstName: NullableStringFieldUpdateOperationsInput
@@ -1535,6 +1538,7 @@ input UserUpdateWithoutCommentsInput {
   interests: UserUpdateinterestsInput
   lastName: NullableStringFieldUpdateOperationsInput
   roles: UserRoleUpdateManyWithoutUsersInput
+  site: SiteUpdateOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaUpdateOneWithoutUserInput
   wantsNewsletter: BoolFieldUpdateOperationsInput
   weddingDate: NullableDateTimeFieldUpdateOperationsInput
@@ -1544,7 +1548,6 @@ input UserUpdateWithoutCommentsInput {
 input UserUpdateWithoutCompaniesInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
-  cat: CatUpdateOneWithoutOwnerInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
   email: StringFieldUpdateOperationsInput
   firstName: NullableStringFieldUpdateOperationsInput
@@ -1553,6 +1556,7 @@ input UserUpdateWithoutCompaniesInput {
   interests: UserUpdateinterestsInput
   lastName: NullableStringFieldUpdateOperationsInput
   roles: UserRoleUpdateManyWithoutUsersInput
+  site: SiteUpdateOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaUpdateOneWithoutUserInput
   wantsNewsletter: BoolFieldUpdateOperationsInput
   weddingDate: NullableDateTimeFieldUpdateOperationsInput
@@ -1562,7 +1566,6 @@ input UserUpdateWithoutCompaniesInput {
 input UserUpdateWithoutRolesInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
-  cat: CatUpdateOneWithoutOwnerInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
   companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
@@ -1571,6 +1574,7 @@ input UserUpdateWithoutRolesInput {
   id: StringFieldUpdateOperationsInput
   interests: UserUpdateinterestsInput
   lastName: NullableStringFieldUpdateOperationsInput
+  site: SiteUpdateOneWithoutOwnerInput
   userSocialMedia: UserSocialMediaUpdateOneWithoutUserInput
   wantsNewsletter: BoolFieldUpdateOperationsInput
   weddingDate: NullableDateTimeFieldUpdateOperationsInput
@@ -1609,7 +1613,6 @@ input UserWhereInput {
   OR: [UserWhereInput!]
   address: JsonNullableFilter
   blogPosts: BlogPostListRelationFilter
-  cat: CatWhereInput
   comments: BlogPostCommentListRelationFilter
   companies: CompanyListRelationFilter
   email: StringFilter
@@ -1619,6 +1622,7 @@ input UserWhereInput {
   interests: EnumTopicNullableListFilter
   lastName: StringNullableFilter
   roles: UserRoleListRelationFilter
+  site: SiteWhereInput
   userSocialMedia: UserSocialMediaWhereInput
   wantsNewsletter: BoolFilter
   weddingDate: DateTimeNullableFilter

--- a/packages/dataprovider/src/buildVariables/buildVariables.test.ts
+++ b/packages/dataprovider/src/buildVariables/buildVariables.test.ts
@@ -726,7 +726,7 @@ describe("buildVariables", () => {
           id: "einstein",
         },
         previousData: {
-          cat: { id: "kitty" },
+          site: { id: 123, url: "thor.com", name: "Theory of relativity" },
         },
       };
 
@@ -739,7 +739,7 @@ describe("buildVariables", () => {
       ).toEqual<NexusGenArgTypes["Mutation"]["updateOneUser"]>({
         where: { id: "einstein" },
         data: {
-          cat: {
+          site: {
             delete: true,
           },
         },

--- a/packages/dataprovider/src/buildVariables/buildVariables.test.ts
+++ b/packages/dataprovider/src/buildVariables/buildVariables.test.ts
@@ -694,7 +694,7 @@ describe("buildVariables", () => {
       });
     });
 
-    it("update an entity and disconnect the related entity", () => {
+    it("update an entity and disconnect the related entity (if disconnect operation is present)", () => {
       const params = {
         data: {
           id: "einstein",
@@ -715,6 +715,32 @@ describe("buildVariables", () => {
         data: {
           userSocialMedia: {
             disconnect: true,
+          },
+        },
+      });
+    });
+
+    it("update an entity and delete the related entity (if disconnect operation is not present)", () => {
+      const params = {
+        data: {
+          id: "einstein",
+        },
+        previousData: {
+          cat: { id: "kitty" },
+        },
+      };
+
+      expect(
+        buildVariables(testIntrospection, options)(
+          testUserResource,
+          UPDATE,
+          params,
+        ),
+      ).toEqual<NexusGenArgTypes["Mutation"]["updateOneUser"]>({
+        where: { id: "einstein" },
+        data: {
+          cat: {
+            delete: true,
           },
         },
       });
@@ -981,6 +1007,37 @@ describe("buildVariables", () => {
             street: "Forth Avenue",
             city: "Ney York",
             countryCode: "US",
+          },
+        },
+      });
+    });
+
+    it("update an entity and delete the related entities if disconnect is not present", () => {
+      const params = {
+        data: {
+          id: "einstein",
+          blogPosts: [],
+        },
+        previousData: {
+          blogPosts: [{ id: "oldId" }],
+        },
+      };
+
+      expect(
+        buildVariables(testIntrospection, options)(
+          testUserResource,
+          UPDATE,
+          params,
+        ),
+      ).toEqual<NexusGenArgTypes["Mutation"]["updateOneUser"]>({
+        where: { id: "einstein" },
+        data: {
+          blogPosts: {
+            delete: [
+              {
+                id: "oldId",
+              },
+            ],
           },
         },
       });

--- a/packages/dataprovider/test-data/datamodel.prisma
+++ b/packages/dataprovider/test-data/datamodel.prisma
@@ -47,6 +47,14 @@ model BlogPostComment {
   authorId String?
 }
 
+model Cat {
+  id     String  @id @default(uuid())
+  name   String
+
+  owner  User?   @relation(fields: [userId], references: [id])
+  userId String?
+}
+
 enum Gender {
   MALE
   FEMALE
@@ -69,6 +77,7 @@ model User {
   comments        BlogPostComment[]
   companies       Company[]
   weddingDate     DateTime?
+  cat             Cat?
 }
 
 model FilteringTest {

--- a/packages/dataprovider/test-data/datamodel.prisma
+++ b/packages/dataprovider/test-data/datamodel.prisma
@@ -47,9 +47,10 @@ model BlogPostComment {
   authorId String?
 }
 
-model Cat {
+model Site {
   id     String  @id @default(uuid())
   name   String
+  url    String
 
   owner  User?   @relation(fields: [userId], references: [id])
   userId String?
@@ -77,7 +78,7 @@ model User {
   comments        BlogPostComment[]
   companies       Company[]
   weddingDate     DateTime?
-  cat             Cat?
+  site            Site?
 }
 
 model FilteringTest {

--- a/packages/dataprovider/test-data/missingPrismaTypesPlugin.ts
+++ b/packages/dataprovider/test-data/missingPrismaTypesPlugin.ts
@@ -1,0 +1,97 @@
+import {
+  InputDefinitionBlock,
+  NexusInputObjectTypeDef,
+  plugin,
+} from "nexus/dist/core";
+import { inputObjectType } from "nexus";
+import {
+  InternalDMMF,
+  getTransformedDmmf,
+} from "nexus-plugin-prisma/dist/dmmf";
+
+import { NexusGenInputs, NexusGenObjects } from "../generated/nexus";
+
+export type NexusInputObjectName = keyof NexusGenInputs;
+
+export type NexusObjectName = keyof Omit<
+  NexusGenObjects,
+  "Mutation" | "Query" | "AffectedRowsOutput"
+>;
+
+type FieldNames<TypeName extends NexusInputObjectName> =
+  keyof NexusGenInputs[TypeName];
+
+export type InputObjectTypeConfig<TypeName extends NexusInputObjectName> = {
+  filteredFields?: Array<FieldNames<TypeName>>;
+  extraDefinition?: (t: InputDefinitionBlock<TypeName>) => void;
+};
+
+const dmmf = getTransformedDmmf("@prisma/client");
+
+function installField(t: InputDefinitionBlock<any>) {
+  return (field: InternalDMMF.SchemaArg) => {
+    let fieldBuilder = t;
+
+    if (field.inputType.isNullable) {
+      // @ts-ignore
+      fieldBuilder = fieldBuilder.nullable;
+    }
+
+    if (field.inputType.isList) {
+      // @ts-ignore
+      fieldBuilder = fieldBuilder.list;
+    }
+
+    fieldBuilder.field(field.name, {
+      // @ts-ignore
+      type: field.inputType.type,
+    });
+  };
+}
+
+export const addMissingTypesPlugin = plugin({
+  name: "missingPrismaTypes",
+  onMissingType(typeName) {
+    // Missing query type should be ignored by our plugin. It wont cause any error.
+    if (typeName === "Query") {
+      return null;
+    }
+
+    const type = dmmf.getInputType(typeName);
+
+    return inputObjectType({
+      name: type.name,
+      definition(t) {
+        type.fields.forEach(installField(t));
+      },
+    });
+  },
+});
+
+export default function prismaInputObjectType<
+  TypeName extends NexusInputObjectName,
+>(
+  name: TypeName,
+  {
+    extraDefinition = () => {
+      // Do nothing
+    },
+    filteredFields = [],
+  }: InputObjectTypeConfig<TypeName>,
+): NexusInputObjectTypeDef<TypeName> {
+  return inputObjectType<TypeName>({
+    name,
+    definition(t) {
+      const { fields } = dmmf.getInputType(name);
+
+      fields
+        .filter((field) => {
+          // @ts-ignore
+          return !filteredFields.includes(field.name);
+        })
+        .forEach(installField(t));
+
+      extraDefinition(t);
+    },
+  });
+}

--- a/packages/dataprovider/test-data/testSchema.ts
+++ b/packages/dataprovider/test-data/testSchema.ts
@@ -11,6 +11,9 @@ import { addCrudResolvers } from "../../backend/src";
 import "../generated/nexus";
 import "../generated/nexus-prisma";
 import { CommonOptions } from "../../backend/src/types";
+import prismaInputObjectType, {
+  addMissingTypesPlugin,
+} from "./missingPrismaTypesPlugin";
 
 const typegenPath = (p: string) => {
   return process.env.PWD && join(process.env.PWD, p);
@@ -141,6 +144,22 @@ export const testSchema = (options: CommonOptions) => {
     },
   });
 
+  const BlogPostUpdateManyWithoutAuthorInput = prismaInputObjectType(
+    "BlogPostUpdateManyWithoutAuthorInput",
+    {
+      // @ts-ignore
+      filteredFields: ["disconnect"],
+    },
+  );
+
+  const CatUpdateOneWithoutOwnerInput = prismaInputObjectType(
+    "CatUpdateOneWithoutOwnerInput",
+    {
+      // @ts-ignore
+      filteredFields: ["disconnect"],
+    },
+  );
+
   const types = [
     User,
     UserRole,
@@ -150,6 +169,8 @@ export const testSchema = (options: CommonOptions) => {
     BlogPost,
     BlogPostComment,
     UserCreateOneWithoutCommentsInput,
+    BlogPostUpdateManyWithoutAuthorInput,
+    CatUpdateOneWithoutOwnerInput,
     FilteringTest,
     Company,
 
@@ -175,6 +196,7 @@ export const testSchema = (options: CommonOptions) => {
               : undefined,
         },
       }),
+      addMissingTypesPlugin,
     ],
 
     outputs:

--- a/packages/dataprovider/test-data/testSchema.ts
+++ b/packages/dataprovider/test-data/testSchema.ts
@@ -152,8 +152,8 @@ export const testSchema = (options: CommonOptions) => {
     },
   );
 
-  const CatUpdateOneWithoutOwnerInput = prismaInputObjectType(
-    "CatUpdateOneWithoutOwnerInput",
+  const SiteUpdateOneWithoutOwnerInput = prismaInputObjectType(
+    "SiteUpdateOneWithoutOwnerInput",
     {
       // @ts-ignore
       filteredFields: ["disconnect"],
@@ -170,7 +170,7 @@ export const testSchema = (options: CommonOptions) => {
     BlogPostComment,
     UserCreateOneWithoutCommentsInput,
     BlogPostUpdateManyWithoutAuthorInput,
-    CatUpdateOneWithoutOwnerInput,
+    SiteUpdateOneWithoutOwnerInput,
     FilteringTest,
     Company,
 


### PR DESCRIPTION
You can force relation deletion upon update by filtering out from your backend gql schema `disconnect` but keeping `delete` in the related `UpdateManyWithout` or `UpdateOneWithout` inputs.
