### PR TITLE
fix: typegraphql total aggregate query

### DIFF
--- a/packages/dataprovider/generated/nexus-prisma.ts
+++ b/packages/dataprovider/generated/nexus-prisma.ts
@@ -14,6 +14,7 @@ type CustomScalars = "Json" | "DateTime";
 // Prisma model type definitions
 interface PrismaModels {
   UserRole: Prisma.UserRole;
+  Company: Prisma.Company;
   UserSocialMedia: Prisma.UserSocialMedia;
   BlogPost: Prisma.BlogPost;
   BlogPostComment: Prisma.BlogPostComment;
@@ -28,6 +29,10 @@ interface NexusPrismaInputs {
     userRoles: {
       filtering: "AND" | "OR" | "NOT" | "id" | "name" | "users";
       ordering: "id" | "name" | "users";
+    };
+    companies: {
+      filtering: "AND" | "OR" | "NOT" | "id" | "name" | "user" | "userId";
+      ordering: "id" | "name" | "user" | "userId";
     };
     userSocialMedias: {
       filtering:
@@ -85,6 +90,7 @@ interface NexusPrismaInputs {
         | "address"
         | "blogPosts"
         | "comments"
+        | "companies"
         | "weddingDate";
       ordering:
         | "id"
@@ -100,6 +106,7 @@ interface NexusPrismaInputs {
         | "address"
         | "blogPosts"
         | "comments"
+        | "companies"
         | "weddingDate";
     };
     filteringTests: {
@@ -153,6 +160,7 @@ interface NexusPrismaInputs {
         | "address"
         | "blogPosts"
         | "comments"
+        | "companies"
         | "weddingDate";
       ordering:
         | "id"
@@ -168,9 +176,11 @@ interface NexusPrismaInputs {
         | "address"
         | "blogPosts"
         | "comments"
+        | "companies"
         | "weddingDate";
     };
   };
+  Company: {};
   UserSocialMedia: {};
   BlogPost: {
     comments: {
@@ -219,6 +229,10 @@ interface NexusPrismaInputs {
         | "authorId";
       ordering: "id" | "text" | "post" | "postId" | "author" | "authorId";
     };
+    companies: {
+      filtering: "AND" | "OR" | "NOT" | "id" | "name" | "user" | "userId";
+      ordering: "id" | "name" | "user" | "userId";
+    };
   };
   FilteringTest: {};
   SomePublicRecordWithIntId: {};
@@ -229,6 +243,8 @@ interface NexusPrismaOutputs {
   Query: {
     userRole: "UserRole";
     userRoles: "UserRole";
+    company: "Company";
+    companies: "Company";
     userSocialMedia: "UserSocialMedia";
     userSocialMedias: "UserSocialMedia";
     blogPost: "BlogPost";
@@ -249,6 +265,12 @@ interface NexusPrismaOutputs {
     deleteOneUserRole: "UserRole";
     deleteManyUserRole: "AffectedRowsOutput";
     upsertOneUserRole: "UserRole";
+    createOneCompany: "Company";
+    updateOneCompany: "Company";
+    updateManyCompany: "AffectedRowsOutput";
+    deleteOneCompany: "Company";
+    deleteManyCompany: "AffectedRowsOutput";
+    upsertOneCompany: "Company";
     createOneUserSocialMedia: "UserSocialMedia";
     updateOneUserSocialMedia: "UserSocialMedia";
     updateManyUserSocialMedia: "AffectedRowsOutput";
@@ -291,6 +313,12 @@ interface NexusPrismaOutputs {
     name: "String";
     users: "User";
   };
+  Company: {
+    id: "String";
+    name: "String";
+    user: "User";
+    userId: "String";
+  };
   UserSocialMedia: {
     id: "String";
     instagram: "String";
@@ -328,6 +356,7 @@ interface NexusPrismaOutputs {
     address: "Json";
     blogPosts: "BlogPost";
     comments: "BlogPostComment";
+    companies: "Company";
     weddingDate: "DateTime";
   };
   FilteringTest: {
@@ -351,6 +380,7 @@ interface NexusPrismaOutputs {
 // Helper to gather all methods relative to a model
 interface NexusPrismaMethods {
   UserRole: Typegen.NexusPrismaFields<"UserRole">;
+  Company: Typegen.NexusPrismaFields<"Company">;
   UserSocialMedia: Typegen.NexusPrismaFields<"UserSocialMedia">;
   BlogPost: Typegen.NexusPrismaFields<"BlogPost">;
   BlogPostComment: Typegen.NexusPrismaFields<"BlogPostComment">;

--- a/packages/dataprovider/generated/nexus.ts
+++ b/packages/dataprovider/generated/nexus.ts
@@ -444,6 +444,116 @@ export interface NexusGenInputs {
     equals?: boolean | null; // Boolean
     not?: NexusGenInputs["NestedBoolFilter"] | null; // NestedBoolFilter
   };
+  CompanyCreateManyUserInput: {
+    // input type
+    id?: string | null; // String
+    name: string; // String!
+  };
+  CompanyCreateManyUserInputEnvelope: {
+    // input type
+    data?: NexusGenInputs["CompanyCreateManyUserInput"][] | null; // [CompanyCreateManyUserInput!]
+    skipDuplicates?: boolean | null; // Boolean
+  };
+  CompanyCreateNestedManyWithoutUserInput: {
+    // input type
+    connect?: NexusGenInputs["CompanyWhereUniqueInput"][] | null; // [CompanyWhereUniqueInput!]
+    connectOrCreate?:
+      | NexusGenInputs["CompanyCreateOrConnectWithoutUserInput"][]
+      | null; // [CompanyCreateOrConnectWithoutUserInput!]
+    create?: NexusGenInputs["CompanyCreateWithoutUserInput"][] | null; // [CompanyCreateWithoutUserInput!]
+    createMany?: NexusGenInputs["CompanyCreateManyUserInputEnvelope"] | null; // CompanyCreateManyUserInputEnvelope
+  };
+  CompanyCreateOrConnectWithoutUserInput: {
+    // input type
+    create: NexusGenInputs["CompanyCreateWithoutUserInput"]; // CompanyCreateWithoutUserInput!
+    where: NexusGenInputs["CompanyWhereUniqueInput"]; // CompanyWhereUniqueInput!
+  };
+  CompanyCreateWithoutUserInput: {
+    // input type
+    id?: string | null; // String
+    name: string; // String!
+  };
+  CompanyListRelationFilter: {
+    // input type
+    every?: NexusGenInputs["CompanyWhereInput"] | null; // CompanyWhereInput
+    none?: NexusGenInputs["CompanyWhereInput"] | null; // CompanyWhereInput
+    some?: NexusGenInputs["CompanyWhereInput"] | null; // CompanyWhereInput
+  };
+  CompanyOrderByRelationAggregateInput: {
+    // input type
+    count: NexusGenEnums["SortOrder"]; // SortOrder!
+  };
+  CompanyScalarWhereInput: {
+    // input type
+    AND?: NexusGenInputs["CompanyScalarWhereInput"][] | null; // [CompanyScalarWhereInput!]
+    NOT?: NexusGenInputs["CompanyScalarWhereInput"][] | null; // [CompanyScalarWhereInput!]
+    OR?: NexusGenInputs["CompanyScalarWhereInput"][] | null; // [CompanyScalarWhereInput!]
+    id?: NexusGenInputs["StringFilter"] | null; // StringFilter
+    name?: NexusGenInputs["StringFilter"] | null; // StringFilter
+    userId?: NexusGenInputs["StringFilter"] | null; // StringFilter
+  };
+  CompanyUpdateManyMutationInput: {
+    // input type
+    id?: NexusGenInputs["StringFieldUpdateOperationsInput"] | null; // StringFieldUpdateOperationsInput
+    name?: NexusGenInputs["StringFieldUpdateOperationsInput"] | null; // StringFieldUpdateOperationsInput
+  };
+  CompanyUpdateManyWithWhereWithoutUserInput: {
+    // input type
+    data: NexusGenInputs["CompanyUpdateManyMutationInput"]; // CompanyUpdateManyMutationInput!
+    where: NexusGenInputs["CompanyScalarWhereInput"]; // CompanyScalarWhereInput!
+  };
+  CompanyUpdateManyWithoutUserInput: {
+    // input type
+    connect?: NexusGenInputs["CompanyWhereUniqueInput"][] | null; // [CompanyWhereUniqueInput!]
+    connectOrCreate?:
+      | NexusGenInputs["CompanyCreateOrConnectWithoutUserInput"][]
+      | null; // [CompanyCreateOrConnectWithoutUserInput!]
+    create?: NexusGenInputs["CompanyCreateWithoutUserInput"][] | null; // [CompanyCreateWithoutUserInput!]
+    createMany?: NexusGenInputs["CompanyCreateManyUserInputEnvelope"] | null; // CompanyCreateManyUserInputEnvelope
+    delete?: NexusGenInputs["CompanyWhereUniqueInput"][] | null; // [CompanyWhereUniqueInput!]
+    deleteMany?: NexusGenInputs["CompanyScalarWhereInput"][] | null; // [CompanyScalarWhereInput!]
+    disconnect?: NexusGenInputs["CompanyWhereUniqueInput"][] | null; // [CompanyWhereUniqueInput!]
+    set?: NexusGenInputs["CompanyWhereUniqueInput"][] | null; // [CompanyWhereUniqueInput!]
+    update?:
+      | NexusGenInputs["CompanyUpdateWithWhereUniqueWithoutUserInput"][]
+      | null; // [CompanyUpdateWithWhereUniqueWithoutUserInput!]
+    updateMany?:
+      | NexusGenInputs["CompanyUpdateManyWithWhereWithoutUserInput"][]
+      | null; // [CompanyUpdateManyWithWhereWithoutUserInput!]
+    upsert?:
+      | NexusGenInputs["CompanyUpsertWithWhereUniqueWithoutUserInput"][]
+      | null; // [CompanyUpsertWithWhereUniqueWithoutUserInput!]
+  };
+  CompanyUpdateWithWhereUniqueWithoutUserInput: {
+    // input type
+    data: NexusGenInputs["CompanyUpdateWithoutUserInput"]; // CompanyUpdateWithoutUserInput!
+    where: NexusGenInputs["CompanyWhereUniqueInput"]; // CompanyWhereUniqueInput!
+  };
+  CompanyUpdateWithoutUserInput: {
+    // input type
+    id?: NexusGenInputs["StringFieldUpdateOperationsInput"] | null; // StringFieldUpdateOperationsInput
+    name?: NexusGenInputs["StringFieldUpdateOperationsInput"] | null; // StringFieldUpdateOperationsInput
+  };
+  CompanyUpsertWithWhereUniqueWithoutUserInput: {
+    // input type
+    create: NexusGenInputs["CompanyCreateWithoutUserInput"]; // CompanyCreateWithoutUserInput!
+    update: NexusGenInputs["CompanyUpdateWithoutUserInput"]; // CompanyUpdateWithoutUserInput!
+    where: NexusGenInputs["CompanyWhereUniqueInput"]; // CompanyWhereUniqueInput!
+  };
+  CompanyWhereInput: {
+    // input type
+    AND?: NexusGenInputs["CompanyWhereInput"][] | null; // [CompanyWhereInput!]
+    NOT?: NexusGenInputs["CompanyWhereInput"][] | null; // [CompanyWhereInput!]
+    OR?: NexusGenInputs["CompanyWhereInput"][] | null; // [CompanyWhereInput!]
+    id?: NexusGenInputs["StringFilter"] | null; // StringFilter
+    name?: NexusGenInputs["StringFilter"] | null; // StringFilter
+    user?: NexusGenInputs["UserWhereInput"] | null; // UserWhereInput
+    userId?: NexusGenInputs["StringFilter"] | null; // StringFilter
+  };
+  CompanyWhereUniqueInput: {
+    // input type
+    id?: string | null; // String
+  };
   DateTimeFieldUpdateOperationsInput: {
     // input type
     set?: NexusGenScalars["DateTime"] | null; // DateTime
@@ -795,6 +905,9 @@ export interface NexusGenInputs {
     comments?:
       | NexusGenInputs["BlogPostCommentCreateNestedManyWithoutAuthorInput"]
       | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
+    companies?:
+      | NexusGenInputs["CompanyCreateNestedManyWithoutUserInput"]
+      | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
     firstName?: string | null; // String
     gender?: NexusGenEnums["Gender"] | null; // Gender
@@ -858,6 +971,9 @@ export interface NexusGenInputs {
     comments?:
       | NexusGenInputs["BlogPostCommentCreateNestedManyWithoutAuthorInput"]
       | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
+    companies?:
+      | NexusGenInputs["CompanyCreateNestedManyWithoutUserInput"]
+      | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
     firstName?: string | null; // String
     gender?: NexusGenEnums["Gender"] | null; // Gender
@@ -878,6 +994,9 @@ export interface NexusGenInputs {
     blogPosts?:
       | NexusGenInputs["BlogPostCreateNestedManyWithoutAuthorInput"]
       | null; // BlogPostCreateNestedManyWithoutAuthorInput
+    companies?:
+      | NexusGenInputs["CompanyCreateNestedManyWithoutUserInput"]
+      | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
     firstName?: string | null; // String
     gender?: NexusGenEnums["Gender"] | null; // Gender
@@ -901,6 +1020,9 @@ export interface NexusGenInputs {
     comments?:
       | NexusGenInputs["BlogPostCommentCreateNestedManyWithoutAuthorInput"]
       | null; // BlogPostCommentCreateNestedManyWithoutAuthorInput
+    companies?:
+      | NexusGenInputs["CompanyCreateNestedManyWithoutUserInput"]
+      | null; // CompanyCreateNestedManyWithoutUserInput
     email: string; // String!
     firstName?: string | null; // String
     gender?: NexusGenEnums["Gender"] | null; // Gender
@@ -935,6 +1057,7 @@ export interface NexusGenInputs {
     comments?:
       | NexusGenInputs["BlogPostCommentOrderByRelationAggregateInput"]
       | null; // BlogPostCommentOrderByRelationAggregateInput
+    companies?: NexusGenInputs["CompanyOrderByRelationAggregateInput"] | null; // CompanyOrderByRelationAggregateInput
     email?: NexusGenEnums["SortOrder"] | null; // SortOrder
     firstName?: NexusGenEnums["SortOrder"] | null; // SortOrder
     gender?: NexusGenEnums["SortOrder"] | null; // SortOrder
@@ -1151,6 +1274,7 @@ export interface NexusGenInputs {
     comments?:
       | NexusGenInputs["BlogPostCommentUpdateManyWithoutAuthorInput"]
       | null; // BlogPostCommentUpdateManyWithoutAuthorInput
+    companies?: NexusGenInputs["CompanyUpdateManyWithoutUserInput"] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs["StringFieldUpdateOperationsInput"] | null; // StringFieldUpdateOperationsInput
     firstName?:
       | NexusGenInputs["NullableStringFieldUpdateOperationsInput"]
@@ -1259,6 +1383,7 @@ export interface NexusGenInputs {
     comments?:
       | NexusGenInputs["BlogPostCommentUpdateManyWithoutAuthorInput"]
       | null; // BlogPostCommentUpdateManyWithoutAuthorInput
+    companies?: NexusGenInputs["CompanyUpdateManyWithoutUserInput"] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs["StringFieldUpdateOperationsInput"] | null; // StringFieldUpdateOperationsInput
     firstName?:
       | NexusGenInputs["NullableStringFieldUpdateOperationsInput"]
@@ -1287,6 +1412,7 @@ export interface NexusGenInputs {
     // input type
     address?: NexusGenScalars["Json"] | null; // Json
     blogPosts?: NexusGenInputs["BlogPostUpdateManyWithoutAuthorInput"] | null; // BlogPostUpdateManyWithoutAuthorInput
+    companies?: NexusGenInputs["CompanyUpdateManyWithoutUserInput"] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs["StringFieldUpdateOperationsInput"] | null; // StringFieldUpdateOperationsInput
     firstName?:
       | NexusGenInputs["NullableStringFieldUpdateOperationsInput"]
@@ -1318,6 +1444,7 @@ export interface NexusGenInputs {
     comments?:
       | NexusGenInputs["BlogPostCommentUpdateManyWithoutAuthorInput"]
       | null; // BlogPostCommentUpdateManyWithoutAuthorInput
+    companies?: NexusGenInputs["CompanyUpdateManyWithoutUserInput"] | null; // CompanyUpdateManyWithoutUserInput
     email?: NexusGenInputs["StringFieldUpdateOperationsInput"] | null; // StringFieldUpdateOperationsInput
     firstName?:
       | NexusGenInputs["NullableStringFieldUpdateOperationsInput"]
@@ -1370,6 +1497,7 @@ export interface NexusGenInputs {
     address?: NexusGenInputs["JsonNullableFilter"] | null; // JsonNullableFilter
     blogPosts?: NexusGenInputs["BlogPostListRelationFilter"] | null; // BlogPostListRelationFilter
     comments?: NexusGenInputs["BlogPostCommentListRelationFilter"] | null; // BlogPostCommentListRelationFilter
+    companies?: NexusGenInputs["CompanyListRelationFilter"] | null; // CompanyListRelationFilter
     email?: NexusGenInputs["StringFilter"] | null; // StringFilter
     firstName?: NexusGenInputs["StringNullableFilter"] | null; // StringNullableFilter
     gender?: NexusGenInputs["EnumGenderNullableFilter"] | null; // EnumGenderNullableFilter
@@ -1427,6 +1555,11 @@ export interface NexusGenObjects {
     // root type
     id: string; // String!
     text: string; // String!
+  };
+  Company: {
+    // root type
+    id: string; // String!
+    name: string; // String!
   };
   FilteringTest: {
     // root type
@@ -1510,6 +1643,11 @@ export interface NexusGenFieldTypes {
     id: string; // String!
     post: NexusGenRootTypes["BlogPost"] | null; // BlogPost
     text: string; // String!
+  };
+  Company: {
+    // field return type
+    id: string; // String!
+    name: string; // String!
   };
   FilteringTest: {
     // field return type
@@ -1600,6 +1738,7 @@ export interface NexusGenFieldTypes {
     address: NexusGenRootTypes["Address"] | null; // Address
     blogPosts: NexusGenRootTypes["BlogPost"][]; // [BlogPost!]!
     comments: NexusGenRootTypes["BlogPostComment"][]; // [BlogPostComment!]!
+    companies: NexusGenRootTypes["Company"][]; // [Company!]!
     email: string; // String!
     firstName: string | null; // String
     gender: NexusGenEnums["Gender"] | null; // Gender
@@ -1652,6 +1791,11 @@ export interface NexusGenFieldTypeNames {
     id: "String";
     post: "BlogPost";
     text: "String";
+  };
+  Company: {
+    // field return type name
+    id: "String";
+    name: "String";
   };
   FilteringTest: {
     // field return type name
@@ -1736,6 +1880,7 @@ export interface NexusGenFieldTypeNames {
     address: "Address";
     blogPosts: "BlogPost";
     comments: "BlogPostComment";
+    companies: "Company";
     email: "String";
     firstName: "String";
     gender: "Gender";
@@ -2088,6 +2233,12 @@ export interface NexusGenArgTypes {
     comments: {
       // args
       cursor?: NexusGenInputs["BlogPostCommentWhereUniqueInput"] | null; // BlogPostCommentWhereUniqueInput
+      skip?: number | null; // Int
+      take?: number | null; // Int
+    };
+    companies: {
+      // args
+      cursor?: NexusGenInputs["CompanyWhereUniqueInput"] | null; // CompanyWhereUniqueInput
       skip?: number | null; // Int
       take?: number | null; // Int
     };

--- a/packages/dataprovider/generated/schema.graphql
+++ b/packages/dataprovider/generated/schema.graphql
@@ -404,6 +404,111 @@ input BoolFilter {
   not: NestedBoolFilter
 }
 
+type Company {
+  id: String!
+  name: String!
+}
+
+input CompanyCreateManyUserInput {
+  id: String
+  name: String!
+}
+
+input CompanyCreateManyUserInputEnvelope {
+  data: [CompanyCreateManyUserInput!]
+  skipDuplicates: Boolean
+}
+
+input CompanyCreateNestedManyWithoutUserInput {
+  connect: [CompanyWhereUniqueInput!]
+  connectOrCreate: [CompanyCreateOrConnectWithoutUserInput!]
+  create: [CompanyCreateWithoutUserInput!]
+  createMany: CompanyCreateManyUserInputEnvelope
+}
+
+input CompanyCreateOrConnectWithoutUserInput {
+  create: CompanyCreateWithoutUserInput!
+  where: CompanyWhereUniqueInput!
+}
+
+input CompanyCreateWithoutUserInput {
+  id: String
+  name: String!
+}
+
+input CompanyListRelationFilter {
+  every: CompanyWhereInput
+  none: CompanyWhereInput
+  some: CompanyWhereInput
+}
+
+input CompanyOrderByRelationAggregateInput {
+  count: SortOrder!
+}
+
+input CompanyScalarWhereInput {
+  AND: [CompanyScalarWhereInput!]
+  NOT: [CompanyScalarWhereInput!]
+  OR: [CompanyScalarWhereInput!]
+  id: StringFilter
+  name: StringFilter
+  userId: StringFilter
+}
+
+input CompanyUpdateManyMutationInput {
+  id: StringFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+}
+
+input CompanyUpdateManyWithWhereWithoutUserInput {
+  data: CompanyUpdateManyMutationInput!
+  where: CompanyScalarWhereInput!
+}
+
+input CompanyUpdateManyWithoutUserInput {
+  connect: [CompanyWhereUniqueInput!]
+  connectOrCreate: [CompanyCreateOrConnectWithoutUserInput!]
+  create: [CompanyCreateWithoutUserInput!]
+  createMany: CompanyCreateManyUserInputEnvelope
+  delete: [CompanyWhereUniqueInput!]
+  deleteMany: [CompanyScalarWhereInput!]
+  disconnect: [CompanyWhereUniqueInput!]
+  set: [CompanyWhereUniqueInput!]
+  update: [CompanyUpdateWithWhereUniqueWithoutUserInput!]
+  updateMany: [CompanyUpdateManyWithWhereWithoutUserInput!]
+  upsert: [CompanyUpsertWithWhereUniqueWithoutUserInput!]
+}
+
+input CompanyUpdateWithWhereUniqueWithoutUserInput {
+  data: CompanyUpdateWithoutUserInput!
+  where: CompanyWhereUniqueInput!
+}
+
+input CompanyUpdateWithoutUserInput {
+  id: StringFieldUpdateOperationsInput
+  name: StringFieldUpdateOperationsInput
+}
+
+input CompanyUpsertWithWhereUniqueWithoutUserInput {
+  create: CompanyCreateWithoutUserInput!
+  update: CompanyUpdateWithoutUserInput!
+  where: CompanyWhereUniqueInput!
+}
+
+input CompanyWhereInput {
+  AND: [CompanyWhereInput!]
+  NOT: [CompanyWhereInput!]
+  OR: [CompanyWhereInput!]
+  id: StringFilter
+  name: StringFilter
+  user: UserWhereInput
+  userId: StringFilter
+}
+
+input CompanyWhereUniqueInput {
+  id: String
+}
+
 scalar DateTime
 
 input DateTimeFieldUpdateOperationsInput {
@@ -854,6 +959,7 @@ type User {
   address: Address
   blogPosts(cursor: BlogPostWhereUniqueInput, skip: Int, take: Int): [BlogPost!]!
   comments(cursor: BlogPostCommentWhereUniqueInput, skip: Int, take: Int): [BlogPostComment!]!
+  companies(cursor: CompanyWhereUniqueInput, skip: Int, take: Int): [Company!]!
   email: String!
   firstName: String
   gender: Gender
@@ -872,6 +978,7 @@ input UserCreateInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
+  companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
   firstName: String
   gender: Gender
@@ -925,6 +1032,7 @@ input UserCreateOrConnectWithoutRolesInput {
 input UserCreateWithoutBlogPostsInput {
   address: Json
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
+  companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
   firstName: String
   gender: Gender
@@ -941,6 +1049,7 @@ input UserCreateWithoutBlogPostsInput {
 input UserCreateWithoutCommentsInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
+  companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
   firstName: String
   gender: Gender
@@ -958,6 +1067,7 @@ input UserCreateWithoutRolesInput {
   address: Json
   blogPosts: BlogPostCreateNestedManyWithoutAuthorInput
   comments: BlogPostCommentCreateNestedManyWithoutAuthorInput
+  companies: CompanyCreateNestedManyWithoutUserInput
   email: String!
   firstName: String
   gender: Gender
@@ -988,6 +1098,7 @@ input UserOrderByWithRelationInput {
   address: SortOrder
   blogPosts: BlogPostOrderByRelationAggregateInput
   comments: BlogPostCommentOrderByRelationAggregateInput
+  companies: CompanyOrderByRelationAggregateInput
   email: SortOrder
   firstName: SortOrder
   gender: SortOrder
@@ -1198,6 +1309,7 @@ input UserUpdateInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
+  companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
   firstName: NullableStringFieldUpdateOperationsInput
   gender: NullableEnumGenderFieldUpdateOperationsInput
@@ -1270,6 +1382,7 @@ input UserUpdateWithWhereUniqueWithoutRolesInput {
 input UserUpdateWithoutBlogPostsInput {
   address: Json
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
+  companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
   firstName: NullableStringFieldUpdateOperationsInput
   gender: NullableEnumGenderFieldUpdateOperationsInput
@@ -1286,6 +1399,7 @@ input UserUpdateWithoutBlogPostsInput {
 input UserUpdateWithoutCommentsInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
+  companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
   firstName: NullableStringFieldUpdateOperationsInput
   gender: NullableEnumGenderFieldUpdateOperationsInput
@@ -1303,6 +1417,7 @@ input UserUpdateWithoutRolesInput {
   address: Json
   blogPosts: BlogPostUpdateManyWithoutAuthorInput
   comments: BlogPostCommentUpdateManyWithoutAuthorInput
+  companies: CompanyUpdateManyWithoutUserInput
   email: StringFieldUpdateOperationsInput
   firstName: NullableStringFieldUpdateOperationsInput
   gender: NullableEnumGenderFieldUpdateOperationsInput
@@ -1343,6 +1458,7 @@ input UserWhereInput {
   address: JsonNullableFilter
   blogPosts: BlogPostListRelationFilter
   comments: BlogPostCommentListRelationFilter
+  companies: CompanyListRelationFilter
   email: StringFilter
   firstName: StringNullableFilter
   gender: EnumGenderNullableFilter

--- a/packages/dataprovider/src/buildGqlQuery.test.ts
+++ b/packages/dataprovider/src/buildGqlQuery.test.ts
@@ -234,6 +234,9 @@ describe("buildGqlQuery", () => {
               comments {
                 id
               }
+              companies {
+                id
+              }
               interests
               weddingDate
               address {
@@ -280,6 +283,9 @@ describe("buildGqlQuery", () => {
                 id
               }
               comments {
+                id
+              }
+              companies {
                 id
               }
               interests
@@ -365,6 +371,9 @@ describe("buildGqlQuery", () => {
               comments {
                 id
               }
+              companies {
+                id
+              }
               interests
               weddingDate
               address {
@@ -412,6 +421,9 @@ describe("buildGqlQuery", () => {
                 id
               }
               comments {
+                id
+              }
+              companies {
                 id
               }
               interests
@@ -462,6 +474,9 @@ describe("buildGqlQuery", () => {
                 id
               }
               comments {
+                id
+              }
+              companies {
                 id
               }
               interests
@@ -515,6 +530,9 @@ describe("buildGqlQuery", () => {
               comments {
                 id
               }
+              companies {
+                id
+              }
               interests
               weddingDate
               address {
@@ -561,6 +579,9 @@ describe("buildGqlQuery", () => {
                 id
               }
               comments {
+                id
+              }
+              companies {
                 id
               }
               interests
@@ -638,6 +659,9 @@ describe("buildGqlQuery", () => {
                   id
                 }
                 comments {
+                  id
+                }
+                companies {
                   id
                 }
                 interests

--- a/packages/dataprovider/src/buildGqlQuery.ts
+++ b/packages/dataprovider/src/buildGqlQuery.ts
@@ -236,12 +236,9 @@ export default (
       })(),
       typegraphql: gqlTypes.field(
         gqlTypes.name(
-          `aggregate${queryType.name
+          `aggregate${resource.type.name
             .substring(0, 1)
-            .toUpperCase()}${queryType.name.substring(
-            1,
-            queryType.name.length - 1,
-          )}`,
+            .toUpperCase()}${resource.type.name.substring(1)}`,
         ),
         {
           alias: gqlTypes.name("total"),

--- a/packages/dataprovider/src/buildQuery.test.ts
+++ b/packages/dataprovider/src/buildQuery.test.ts
@@ -288,6 +288,72 @@ describe("buildQueryFactory", () => {
           }
         `);
       });
+      it("for get list fetch with typegraphql count option - plural ending in 'ies'", () => {
+        const buildQuery = buildQueryFactory(testIntrospection, {
+          queryDialect: "typegraphql",
+          resourceViews: {
+            CompanyWithUser: {
+              resource: "Company",
+              fragment: {
+                one: gqlReal`
+                  fragment OneCompanyWithUser on Company {
+                    id
+                    user {
+                      id
+                      email
+                    }
+                  }
+                `,
+                many: gqlReal`
+                  fragment ManyCompaniesWithUser on Company {
+                    id
+                    user {
+                        id
+                        email
+                    }
+                  }
+                `,
+              },
+            },
+          },
+        });
+
+        const { query } = buildQuery("GET_LIST", "CompanyWithUser", {
+          pagination: {
+            page: 1,
+            perPage: 50,
+          },
+          filter: {},
+          sort: { field: "id", order: "ASC" },
+        } as GetListParams);
+
+        expect(query).toEqualGraphql(gql`
+          query companies(
+            $where: CompanyWhereInput
+            $orderBy: [CompanyOrderByWithRelationInput!]
+            $take: Int
+            $skip: Int
+          ) {
+            items: companies(
+              where: $where
+              orderBy: $orderBy
+              take: $take
+              skip: $skip
+            ) {
+              id
+              user {
+                id
+                email
+              }
+            }
+            total: aggregateCompany(where: $where) {
+              count {
+                _all
+              }
+            }
+          }
+        `);
+      });
 
       it("for get list fetch with typegraphql count option, without order", () => {
         const buildQuery = buildQueryFactory(testIntrospection, {

--- a/packages/dataprovider/test-data/datamodel.prisma
+++ b/packages/dataprovider/test-data/datamodel.prisma
@@ -14,6 +14,13 @@ model UserRole {
   users User[] @relation(references: [id])
 }
 
+model Company {
+  id    String @id @default(uuid())
+  name  String
+  user  User   @relation(fields: [userId], references: [id])
+  userId String
+}
+
 model UserSocialMedia {
   id        String @id @default(uuid())
   instagram String
@@ -60,6 +67,7 @@ model User {
   address         Json?
   blogPosts       BlogPost[]
   comments        BlogPostComment[]
+  companies       Company[]
   weddingDate     DateTime?
 }
 

--- a/packages/dataprovider/test-data/testSchema.ts
+++ b/packages/dataprovider/test-data/testSchema.ts
@@ -31,6 +31,7 @@ export const testSchema = (options: CommonOptions) => {
       t.model.userSocialMedia(null);
       t.model.blogPosts(null);
       t.model.comments(null);
+      t.model.companies(null);
       t.model.interests();
       t.model.weddingDate();
       t.field("address", { type: "Address" });
@@ -48,6 +49,14 @@ export const testSchema = (options: CommonOptions) => {
 
   const UserRole = objectType({
     name: "UserRole",
+    definition(t) {
+      t.model.id();
+      t.model.name();
+    },
+  });
+
+  const Company = objectType({
+    name: "Company",
     definition(t) {
       t.model.id();
       t.model.name();
@@ -142,7 +151,9 @@ export const testSchema = (options: CommonOptions) => {
     BlogPostComment,
     UserCreateOneWithoutCommentsInput,
     FilteringTest,
+    Company,
 
+    addCrudResolvers("Company", options),
     addCrudResolvers("User", options),
     addCrudResolvers("UserRole", options),
     addCrudResolvers("SomePublicRecordWithIntId", options),


### PR DESCRIPTION
With `typegraphql` given a model named `Company` then a `GET_LIST` query is meant to be plural, i.e. `query companies...`. 

The total count can be retrieved by using `aggregateCompany` though, where `Company` is singular.

Currently such cases were handled by `packages/dataprovider/src/buildGqlQuery.ts` by simply stripping out the last character (in most cases an "s") from `queryType.name`, which is the model's plural.

I believe it should be safe to rely on `resource.type.name` (which should be always singular) instead since this breaks for any noun that isn't pluralized by simply adding an "s" at the end (company => companies).

I added a model named `Company` related to `User` and a unit test to showcase and cover this scenario.

Best regards.
