### PR TITLE
fix: typegraphql aggregation query count property

### DIFF
--- a/packages/dataprovider/src/buildGqlQuery.test.ts
+++ b/packages/dataprovider/src/buildGqlQuery.test.ts
@@ -297,7 +297,7 @@ describe("buildGqlQuery", () => {
               }
             }
             total: aggregateUser(where: $where) {
-              count {
+              _count {
                 _all
               }
             }

--- a/packages/dataprovider/src/buildGqlQuery.ts
+++ b/packages/dataprovider/src/buildGqlQuery.ts
@@ -272,7 +272,7 @@ export default (
           alias: gqlTypes.name("total"),
           arguments: countArgs,
           selectionSet: gqlTypes.selectionSet([
-            gqlTypes.field(gqlTypes.name("count"), {
+            gqlTypes.field(gqlTypes.name("_count"), {
               selectionSet: gqlTypes.selectionSet([
                 gqlTypes.field(gqlTypes.name("_all")),
               ]),

--- a/packages/dataprovider/src/buildQuery.test.ts
+++ b/packages/dataprovider/src/buildQuery.test.ts
@@ -394,7 +394,7 @@ describe("buildQueryFactory", () => {
               }
             }
             total: aggregateUser(where: $where) {
-              count {
+              _count {
                 _all
               }
             }
@@ -460,7 +460,7 @@ describe("buildQueryFactory", () => {
               }
             }
             total: aggregateCompany(where: $where) {
-              count {
+              _count {
                 _all
               }
             }
@@ -518,7 +518,7 @@ describe("buildQueryFactory", () => {
               }
             }
             total: aggregateUser(where: $where) {
-              count {
+              _count {
                 _all
               }
             }

--- a/packages/dataprovider/src/buildVariables/buildData.ts
+++ b/packages/dataprovider/src/buildVariables/buildData.ts
@@ -145,7 +145,12 @@ const buildNewInputValue = (
         (i) => i.name === ModifiersParams.delete,
       );
 
-      if (setModifier && !connectModifier && !disconnectModifier && !deleteModifier) {
+      if (
+        setModifier &&
+        !connectModifier &&
+        !disconnectModifier &&
+        !deleteModifier
+      ) {
         // if its a date, convert it to a date
         if (
           setModifier.type.kind === "SCALAR" &&

--- a/packages/dataprovider/src/getResponseParser.test.ts
+++ b/packages/dataprovider/src/getResponseParser.test.ts
@@ -98,7 +98,7 @@ const testListTypes = (type: string) => {
             ],
           },
         ],
-        total: { count: { _all: 100 } },
+        total: { _count: { _all: 100 } },
       },
     };
 

--- a/packages/dataprovider/src/getResponseParser.ts
+++ b/packages/dataprovider/src/getResponseParser.ts
@@ -71,7 +71,7 @@ export default (
         case "nexus-prisma":
           return response.data.total;
         case "typegraphql":
-          return response.data.total.count._all;
+          return response.data.total._count._all;
       }
     };
 


### PR DESCRIPTION
Since [typegraphql-prisma v0.14.3](https://github.com/MichalLytek/typegraphql-prisma/releases/tag/v0.14.3) an underscore has been added to all aggregation properties hence `count` should be renamed to `_count`.