### PR TITLE
fix: #117 handling noncount nouns / no plural forms by configuring operation names

### DIFF
--- a/packages/dataprovider/README.md
+++ b/packages/dataprovider/README.md
@@ -485,6 +485,31 @@ useDataProvider({
 })
 ```
 
+## customize operation names:
+
+This allows you to customize operation names for example when the names cannot
+be pluralized (for one/many) or if you have custom operation names that you
+would like to be called instead.
+
+It will utilize the default operation names if one is not provided for any
+particular key.
+
+```
+
+useDataProvider({
+  // ...
+  operationNames: {
+    RESOURCE_NAME: {
+      create: "myCreateOperation",
+      update: "myUpdateOperation",
+      delete: "myDeleteOperation",
+      one: "myFindOneOperation",
+      many: "myFindManyOperation",
+    },
+  },
+})
+```
+
 ## Usage with typegraphql-prisma
 
 (beta)

--- a/packages/dataprovider/src/types.ts
+++ b/packages/dataprovider/src/types.ts
@@ -76,6 +76,11 @@ export type ConfigOptions = {
   };
   customizeInputData?: CustomizeInputData;
   introspection?: IntrospectionOptions;
+  operationNames?: {
+    [name: string]: {
+      [name: string]: string;
+    };
+  };
 };
 
 export type FetchType =

--- a/packages/dataprovider/src/utils/makeIntrospectionOptions.ts
+++ b/packages/dataprovider/src/utils/makeIntrospectionOptions.ts
@@ -18,25 +18,42 @@ export const makeIntrospectionOptions = (options: OurOptions) => {
 
   const mutationOperationNames: Record<QueryDialect, object> = {
     "nexus-prisma": {
-      [CREATE]: (resource: Resource) => prefix(`createOne${resource.name}`),
-      [UPDATE]: (resource: Resource) => prefix(`updateOne${resource.name}`),
-      [DELETE]: (resource: Resource) => prefix(`deleteOne${resource.name}`),
+      [CREATE]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.create ||
+        prefix(`createOne${resource.name}`),
+      [UPDATE]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.update ||
+        prefix(`updateOne${resource.name}`),
+      [DELETE]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.delete ||
+        prefix(`deleteOne${resource.name}`),
     },
     typegraphql: {
-      [CREATE]: (resource: Resource) => prefix(`create${resource.name}`),
-      [UPDATE]: (resource: Resource) => prefix(`update${resource.name}`),
-      [DELETE]: (resource: Resource) => prefix(`delete${resource.name}`),
+      [CREATE]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.create ||
+        prefix(`create${resource.name}`),
+      [UPDATE]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.update ||
+        prefix(`update${resource.name}`),
+      [DELETE]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.delete ||
+        prefix(`delete${resource.name}`),
     },
   };
 
   return {
     operationNames: {
       [GET_LIST]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.many ||
         prefix(`${pluralize(camelCase(resource.name))}`),
-      [GET_ONE]: (resource: Resource) => prefix(`${camelCase(resource.name)}`),
+      [GET_ONE]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.one ||
+        prefix(`${camelCase(resource.name)}`),
       [GET_MANY]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.many ||
         prefix(`${pluralize(camelCase(resource.name))}`),
       [GET_MANY_REFERENCE]: (resource: Resource) =>
+        options?.operationNames?.[resource.name]?.many ||
         prefix(`${pluralize(camelCase(resource.name))}`),
 
       ...mutationOperationNames[options.queryDialect],


### PR DESCRIPTION
Provide a way to override operation names to handle edge cases where the resource name is not the actual operation or the operations were customized

```
useDataProvider({
  operationNames: {
    RESOURCE_NAME: {
      create: "myCreateOperation",
      update: "myUpdateOperation",
      delete: "myDeleteOperation",
      one: "myOneOperation",
      many: "myManyOperation"
    }
  }
});
```