### PR TITLE
Query Operation Names + TypeGraphQL Default Pluralization Support

### DIFF
--- a/packages/dataprovider/.prisma/index.js
+++ b/packages/dataprovider/.prisma/index.js
@@ -209,7 +209,7 @@ const config = {
       "value": "prisma-client-js"
     },
     "output": {
-      "value": "/Users/macrozone/git/panter/ra-data-prisma/packages/dataprovider/.prisma",
+      "value": "/Volumes/Projects/ra-data-prisma/packages/dataprovider/.prisma",
       "fromEnvVar": null
     },
     "config": {
@@ -247,7 +247,7 @@ const PrismaClient = getPrismaClient(config)
 exports.PrismaClient = PrismaClient
 Object.assign(exports, Prisma)
 
-path.join(__dirname, "libquery_engine-darwin-arm64.dylib.node");
-path.join(process.cwd(), ".prisma/libquery_engine-darwin-arm64.dylib.node")
+path.join(__dirname, "libquery_engine-darwin.dylib.node");
+path.join(process.cwd(), ".prisma/libquery_engine-darwin.dylib.node")
 path.join(__dirname, "schema.prisma");
 path.join(process.cwd(), ".prisma/schema.prisma")

--- a/packages/dataprovider/README.md
+++ b/packages/dataprovider/README.md
@@ -547,13 +547,15 @@ const dataProvider = useDataProvider({
 })
 ```
 
-### override mutation operation names due to prisma versions breaking changes
+### override mutation or query operation names due to prisma versions breaking changes
 
 You can override operation names depending on the version of typegraphql-prisma you are using:
 
 ```ts
-import { CREATE, UPDATE, DELETE } from "react-admin";
+import { CREATE, UPDATE, DELETE, GET_LIST, GET_MANY, GET_MANY_REFERENCE, GET_ONE } from "react-admin";
 import { Options } from "@ra-data-prisma/dataprovider";
+import camelCase from "lodash/camelCase";
+import pluralize from "pluralize";
 
 const options: Options = {
   queryDialect: "typegraphql",
@@ -564,6 +566,14 @@ const options: Options = {
       [DELETE]: (resource) => `deleteOne${resource.name}`,
     },
   },
+  queryOperationNames: {
+    typegraphql: {
+      [GET_LIST]: (resource) => `${pluralize(camelCase(resource.name))}`,
+      [GET_MANY]: (resource) => `${pluralize(camelCase(resource.name))}`,
+      [GET_MANY_REFERENCE]: (resource) => `${pluralize(camelCase(resource.name))}`,
+      [GET_ONE]: (resource) => `${camelCase(resource.name)}`,
+    },
+  }
 };
 ```
 
@@ -587,5 +597,13 @@ const options: Options = {
       [DELETE]: (resource) => prefix(`deleteOne${resource.name}`),
     },
   },
+  queryOperationNames: {
+    typegraphql: {
+      [GET_LIST]: (resource) => prefix(`${pluralize(camelCase(resource.name))}`),
+      [GET_MANY]: (resource) => prefix(`${pluralize(camelCase(resource.name))}`),
+      [GET_MANY_REFERENCE]: (resource) => prefix(`${pluralize(camelCase(resource.name))}`),
+      [GET_ONE]: (resource) => prefix(`${camelCase(resource.name)}`),
+    },
+  }
 };
 ```

--- a/packages/dataprovider/src/types.ts
+++ b/packages/dataprovider/src/types.ts
@@ -95,6 +95,7 @@ export type ConfigOptions = {
   customizeInputData?: CustomizeInputData;
   introspection?: IntrospectionOptions;
   mutationOperationNames?: MutationOperationNames;
+  queryOperationNames?: QueryOperationNames;
 };
 
 export type QueryFetchType =
@@ -102,6 +103,14 @@ export type QueryFetchType =
   | typeof GET_MANY
   | typeof GET_MANY_REFERENCE
   | typeof GET_ONE;
+
+export type QueryOperationNameMap = {
+  [K in QueryFetchType]: (resource: Resource) => string;
+};
+
+export type QueryOperationNames = Partial<
+  Record<QueryDialect, QueryOperationNameMap>
+>;
 
 export type FetchType = QueryFetchType | MutationFetchType;
 

--- a/packages/dataprovider/src/utils/makeIntrospectionOptions.ts
+++ b/packages/dataprovider/src/utils/makeIntrospectionOptions.ts
@@ -41,13 +41,34 @@ export const makeIntrospectionOptions = (options: OurOptions) => {
         prefix(`${pluralize(camelCase(resource.name))}`),
     },
     typegraphql: {
-      [GET_LIST]: (resource: Resource) =>
-        prefix(`${pluralize(camelCase(resource.name))}`),
-      [GET_ONE]: (resource: Resource) => prefix(`${camelCase(resource.name)}`),
-      [GET_MANY]: (resource: Resource) =>
-        prefix(`${pluralize(camelCase(resource.name))}`),
-      [GET_MANY_REFERENCE]: (resource: Resource) =>
-        prefix(`${pluralize(camelCase(resource.name))}`),
+      [GET_LIST]: (resource: Resource) => {
+        const pluralName = pluralize(resource.name);
+        if (resource.name === pluralName) {
+          return prefix(`findMany${resource.name}`);
+        }
+        return prefix(`${pluralize(camelCase(resource.name))}`);
+      },
+      [GET_ONE]: (resource: Resource) => {
+        const pluralName = pluralize(resource.name);
+        if (resource.name === pluralName) {
+          return prefix(`findUnique${resource.name}`);
+        }
+        return prefix(`${camelCase(resource.name)}`);
+      },
+      [GET_MANY]: (resource: Resource) => {
+        const pluralName = pluralize(resource.name);
+        if (resource.name === pluralName) {
+          return prefix(`findMany${resource.name}`);
+        }
+        return prefix(`${pluralize(camelCase(resource.name))}`);
+      },
+      [GET_MANY_REFERENCE]: (resource: Resource) => {
+        const pluralName = pluralize(resource.name);
+        if (resource.name === pluralName) {
+          return prefix(`findMany${resource.name}`);
+        }
+        return prefix(`${pluralize(camelCase(resource.name))}`);
+      },
     },
     ...options.queryOperationNames,
   };

--- a/packages/dataprovider/src/utils/makeIntrospectionOptions.ts
+++ b/packages/dataprovider/src/utils/makeIntrospectionOptions.ts
@@ -30,8 +30,8 @@ export const makeIntrospectionOptions = (options: OurOptions) => {
     ...options.mutationOperationNames,
   };
 
-  return {
-    operationNames: {
+  const queryOperationNames: Record<QueryDialect, object> = {
+    "nexus-prisma": {
       [GET_LIST]: (resource: Resource) =>
         prefix(`${pluralize(camelCase(resource.name))}`),
       [GET_ONE]: (resource: Resource) => prefix(`${camelCase(resource.name)}`),
@@ -39,7 +39,22 @@ export const makeIntrospectionOptions = (options: OurOptions) => {
         prefix(`${pluralize(camelCase(resource.name))}`),
       [GET_MANY_REFERENCE]: (resource: Resource) =>
         prefix(`${pluralize(camelCase(resource.name))}`),
+    },
+    typegraphql: {
+      [GET_LIST]: (resource: Resource) =>
+        prefix(`${pluralize(camelCase(resource.name))}`),
+      [GET_ONE]: (resource: Resource) => prefix(`${camelCase(resource.name)}`),
+      [GET_MANY]: (resource: Resource) =>
+        prefix(`${pluralize(camelCase(resource.name))}`),
+      [GET_MANY_REFERENCE]: (resource: Resource) =>
+        prefix(`${pluralize(camelCase(resource.name))}`),
+    },
+    ...options.queryOperationNames,
+  };
 
+  return {
+    operationNames: {
+      ...queryOperationNames[options.queryDialect],
       ...mutationOperationNames[options.queryDialect],
     },
     exclude: undefined,


### PR DESCRIPTION
* Provides the ability to specify queryOperationNames configuration options to alter the GET_ONE, GET_MANY, GET_MANY_REFERENCE and GET_LIST operations. This is particularily useful when typegraphql-prisma cannot find a plural word.
* When typegraphql-prisma cannot pluralize a word, it changes the query functions to not have a pluralized form and instead uses prefixes such as findMany and findUnique in front of those resources. This fix changes the default if we encounter one of those types of words.