### PR TITLE
support SortOrderInput for typegraphql

### DIFF
--- a/packages/dataprovider/src/buildVariables/buildOrderBy.ts
+++ b/packages/dataprovider/src/buildVariables/buildOrderBy.ts
@@ -1,4 +1,4 @@
-import { IntrospectionInputObjectType } from "graphql";
+import { IntrospectionInputObjectType, IntrospectionInputValue } from "graphql";
 import set from "lodash/set";
 import type { GetListParams } from ".";
 import { BuildVariablesContext } from "./types";
@@ -14,6 +14,28 @@ function getOrderType({
     (t) => t.name === withRelation || t.name === withoutRelation,
   ) as IntrospectionInputObjectType;
 }
+
+const getFieldType = (
+  context: BuildVariablesContext,
+  orderType: IntrospectionInputObjectType,
+  fieldParts: string[],
+): IntrospectionInputValue | null => {
+  if (fieldParts.length === 0) return null;
+
+  const [currentField, ...remainingFields] = fieldParts;
+  const fieldType = orderType.inputFields.find((f) => f.name === currentField);
+
+  if (!fieldType) return null;
+  if (remainingFields.length === 0) return fieldType;
+  if (fieldType.type.kind !== "INPUT_OBJECT") return null;
+
+  const name = fieldType.type.name;
+  const nextOrderType = context.introspectionResults.types.find(
+    (t) => t.name === name,
+  ) as IntrospectionInputObjectType;
+
+  return getFieldType(context, nextOrderType, remainingFields);
+};
 
 export const buildOrderBy = (
   sort: GetListParams["sort"],
@@ -32,6 +54,20 @@ export const buildOrderBy = (
     return null;
   }
   const selector = {};
+
+  if (context.options.queryDialect === "typegraphql") {
+    const fieldType = getFieldType(context, orderType, fieldParts);
+    if (!fieldType) return null;
+
+    if (
+      fieldType.type.kind === "INPUT_OBJECT" &&
+      fieldType.type.name === "SortOrderInput"
+    ) {
+      set(selector, field, { sort: sort.order === "ASC" ? "asc" : "desc" });
+
+      return [selector];
+    }
+  }
 
   if (context.options.queryDialect === "pothos-prisma") {
     set(selector, field, sort.order === "ASC" ? "Asc" : "Desc");


### PR DESCRIPTION
v0.27.0 of typegraphql-prisma bumped prisma up to v5 wherein `orderByNulls` is enabled by default. This causes a breaking change in the emitted schema due to the type of the sort input type values being either `SortOrder` or `SortOrderInput` depending on if the field being sorted on is non-nullable or nullable respectively.
This implementation addresses that breaking change and should be backwards compatible as it allows for either of the two options to be used based on the introspection results.